### PR TITLE
Fix saving notes without picture

### DIFF
--- a/server/src/main/java/com/memoritta/server/manager/ItemManager.java
+++ b/server/src/main/java/com/memoritta/server/manager/ItemManager.java
@@ -33,19 +33,26 @@ public class ItemManager {
                 .name(name)
                 .id(UUID.randomUUID())
                 .build();
+
         Description description = null;
-        if (picture != null) {
+
+        // Create description if any optional field was provided
+        if (picture != null || note != null || barCode != null) {
             description = Description.builder().build();
-            byte[] imageBytes = picture.getBytes();
-            PictureOfItem pictureOfItem = PictureOfItem.builder().build();
-            pictureOfItem.setPicture(imageBytes);
-            description.setPictures(List.of(pictureOfItem));
+
+            if (picture != null) {
+                byte[] imageBytes = picture.getBytes();
+                PictureOfItem pictureOfItem = PictureOfItem.builder().build();
+                pictureOfItem.setPicture(imageBytes);
+                description.setPictures(List.of(pictureOfItem));
+            }
+
             description.setNote(note);
             description.setBarcode(barCode);
             item.setDescription(description);
         }
-        UUID id = save(item);
 
+        UUID id = save(item);
         return id;
     }
 


### PR DESCRIPTION
## Summary
- ensure ItemManager saves notes and barcodes even when no image is provided

## Testing
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_683f4283e3048327bb28f5789adfb4ea