### PR TITLE
Add /items/search endpoint

### DIFF
--- a/server/src/main/java/com/memoritta/server/controller/ItemController.java
+++ b/server/src/main/java/com/memoritta/server/controller/ItemController.java
@@ -2,6 +2,7 @@ package com.memoritta.server.controller;
 
 import com.memoritta.server.manager.ItemManager;
 import com.memoritta.server.model.Item;
+import com.memoritta.server.model.SearchSimilarRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.AllArgsConstructor;
@@ -79,6 +80,19 @@ public class ItemController {
     ) {
         List<UUID> listItems = itemManager.listItems(email); // TODO add support for JWT
         return listItems;
+    }
+
+    @PostMapping("/items/search")
+    @Operation(
+            summary = "Search items similar to the given item ID",
+            description = "Returns a list of items similar to the provided ID. Currently returns a single item list with the requested item."
+    )
+    public List<Item> searchSimilarItems(
+            @RequestBody
+            @Parameter(description = "Search parameters containing the item ID")
+            SearchSimilarRequest request
+    ) {
+        return itemManager.searchSimilarItems(request.getId());
     }
 
 }

--- a/server/src/main/java/com/memoritta/server/manager/ItemManager.java
+++ b/server/src/main/java/com/memoritta/server/manager/ItemManager.java
@@ -76,7 +76,17 @@ public class ItemManager {
     }
 
     public Item fetchItem(String id) {
-        return null;
+        return itemRepository.findById(UUID.fromString(id))
+                .map(ItemMapper.INSTANCE::toItem)
+                .orElse(null);
+    }
+
+    public List<Item> searchSimilarItems(String id) {
+        Item item = fetchItem(id);
+        if (item == null) {
+            return List.of();
+        }
+        return List.of(item);
     }
 
     public List<UUID> listItems(String email) {

--- a/server/src/main/java/com/memoritta/server/model/SearchSimilarRequest.java
+++ b/server/src/main/java/com/memoritta/server/model/SearchSimilarRequest.java
@@ -1,0 +1,15 @@
+package com.memoritta.server.model;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+@Getter
+@Setter
+@Builder
+public class SearchSimilarRequest {
+    private String id;
+    private Map<String, String> parameters;
+}

--- a/server/src/test/java/com/memoritta/server/controller/ItemControllerTest.java
+++ b/server/src/test/java/com/memoritta/server/controller/ItemControllerTest.java
@@ -8,6 +8,7 @@ import com.memoritta.server.manager.BinaryDataManager;
 import com.memoritta.server.manager.ItemManager;
 import com.memoritta.server.mapper.ItemMapper;
 import com.memoritta.server.model.Item;
+import com.memoritta.server.model.SearchSimilarRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -23,6 +24,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -112,6 +114,27 @@ class ItemControllerTest {
         assertThat(parsedUuid).isNotNull();
 
         verify(itemRepository).save(any(ItemDao.class));
+    }
+
+    @Test
+    void testSearchSimilarItems_shouldReturnSingleItem() {
+        // Given
+        UUID id = UUID.randomUUID();
+        when(itemRepository.findById(id)).thenReturn(java.util.Optional.of(ItemDao.builder().id(id).build()));
+
+        SearchSimilarRequest request = SearchSimilarRequest.builder()
+                .id(id.toString())
+                .build();
+
+        // When
+        List<Item> result = itemController.searchSimilarItems(request);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals(id, result.get(0).getId());
+
+        verify(itemRepository).findById(id);
     }
 
 }


### PR DESCRIPTION
## Summary
- add `SearchSimilarRequest` data class for search parameters
- implement dummy search in `ItemManager`
- expose `/items/search` POST endpoint
- cover search endpoint with tests

## Testing
- `mvn -q -pl server test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_683f52d10db88327941d37f654d943a6