### PR TITLE
Add JWT support

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -39,9 +39,18 @@ docker run --name redis -d -p 6379:6379 redis
 ```bash
   redis-cli  --user default  --pass ****
 ```
-## Certificates generate
+## JWT Secret
 
-````aiignore
-openssl genpkey -algorithm RSA -out private.pem -pkeyopt rsa_keygen_bits:2048
-openssl rsa -pubout -in private.pem -out public.pem
-````
+The application now uses an HMAC secret for signing JWT tokens. Configure the
+secret in `application.yml`:
+
+```yaml
+spring:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          secret: <your-very-long-secret>
+```
+
+Ensure the secret is at least 32 characters long.

--- a/server/src/main/java/com/memoritta/server/config/SecurityConfig.java
+++ b/server/src/main/java/com/memoritta/server/config/SecurityConfig.java
@@ -29,17 +29,16 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-//                .oauth2ResourceServer(oauth2 -> oauth2
-//                        .jwt(jwt -> jwt
-//                                .jwtAuthenticationConverter(jwtAuthenticationConverter())
-//                        )
-//                )
+                .oauth2ResourceServer(oauth2 -> oauth2
+                        .jwt(jwt -> jwt
+                                .jwtAuthenticationConverter(jwtAuthenticationConverter())
+                        )
+                )
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/login", "/user").permitAll()
                         .anyRequest().authenticated()
-                )
-                .httpBasic(withDefaults());
+                );
 
         return http.build();
     }

--- a/server/src/main/java/com/memoritta/server/controller/UserController.java
+++ b/server/src/main/java/com/memoritta/server/controller/UserController.java
@@ -5,6 +5,7 @@ import com.memoritta.server.model.AuthenticatedUser;
 import com.memoritta.server.model.Credentials;
 import com.memoritta.server.model.User;
 import com.memoritta.server.utils.PasswordUtils;
+import com.memoritta.server.security.JwtUtil;
 import com.memoritta.server.utils.UserUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -19,6 +20,7 @@ import java.util.UUID;
 public class UserController {
 
     private PasswordUtils passwordUtils;
+    private JwtUtil jwtUtil;
     private UserUtils userUtils;
     private UserAccessManager userAccessManager;
 
@@ -36,7 +38,7 @@ public class UserController {
         User user = userAccessManager.authenticateAndFetchUser(credentials.getEmail(), credentials.getPassword());
         AuthenticatedUser authenticatedUser = AuthenticatedUser.builder()
                 .user(user)
-                .jwtToken(passwordUtils.generateJwtToken(user))
+                .jwtToken(jwtUtil.generateToken(user.getEmail()))
                 .build();
         return authenticatedUser;
     }

--- a/server/src/main/java/com/memoritta/server/security/JwtUtil.java
+++ b/server/src/main/java/com/memoritta/server/security/JwtUtil.java
@@ -2,6 +2,7 @@ package com.memoritta.server.security;
 
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
@@ -10,8 +11,12 @@ import java.util.Date;
 
 @Component
 public class JwtUtil {
-    private static final String SECRET = "Q+FQIAMDM+KevA+A3qnUiHO0eo27QB3tm2ahv3WqDlw="; // min. 32 znaki
-    private static final Key SECRET_KEY = Keys.hmacShaKeyFor(SECRET.getBytes());
+
+    private final Key secretKey;
+
+    public JwtUtil(@Value("${spring.security.oauth2.resourceserver.jwt.secret}") String secret) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes());
+    }
 
     // Generuje token JWT
     public String generateToken(String username) {
@@ -19,7 +24,7 @@ public class JwtUtil {
                 .subject(username)
                 .issuedAt(new Date())
                 .expiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 10)) // 10h
-                .signWith(SECRET_KEY)
+                .signWith(secretKey)
                 .compact();
     }
 
@@ -37,7 +42,7 @@ public class JwtUtil {
 
     private Claims getClaims(String token) {
         JwtParser parser = Jwts.parser()
-                .verifyWith((SecretKey) SECRET_KEY)
+                .verifyWith((SecretKey) secretKey)
                 .build();
 
         return parser.parseSignedClaims(token).getPayload();

--- a/server/src/main/java/com/memoritta/server/utils/PasswordUtils.java
+++ b/server/src/main/java/com/memoritta/server/utils/PasswordUtils.java
@@ -1,7 +1,5 @@
 package com.memoritta.server.utils;
 
-import com.memoritta.server.model.User;
-import lombok.AllArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -20,7 +18,4 @@ public class PasswordUtils {
         }
     }
 
-    public String generateJwtToken(User user) {
-        return "jwt-token-for-" + user.getId() + "-" + user.getEmail();
-    }
 }

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          public-key-location: classpath:public.pem
+          secret: Q+FQIAMDM+KevA+A3qnUiHO0eo27QB3tm2ahv3WqDlw=
     user:
       name: admin
       password: admin

--- a/server/src/test/java/com/memoritta/server/controller/UserControllerTest.java
+++ b/server/src/test/java/com/memoritta/server/controller/UserControllerTest.java
@@ -10,6 +10,7 @@ import com.memoritta.server.model.Credentials;
 import com.memoritta.server.model.User;
 import com.memoritta.server.utils.PasswordUtils;
 import com.memoritta.server.utils.UserUtils;
+import com.memoritta.server.security.JwtUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 @SpringBootTest
-@ContextConfiguration(classes = {UserControllerTest.Config.class, PasswordUtils.class, UserUtils.class, UserController.class, UserAccessManager.class, UserRepository.class})
+@ContextConfiguration(classes = {UserControllerTest.Config.class, PasswordUtils.class, UserUtils.class, JwtUtil.class, UserController.class, UserAccessManager.class, UserRepository.class})
 class UserControllerTest {
 
     @Autowired

--- a/server/src/test/java/com/memoritta/server/manager/UserAccessManagerTest.java
+++ b/server/src/test/java/com/memoritta/server/manager/UserAccessManagerTest.java
@@ -9,6 +9,7 @@ import com.memoritta.server.model.Credentials;
 import com.memoritta.server.model.User;
 import com.memoritta.server.utils.PasswordUtils;
 import com.memoritta.server.utils.UserUtils;
+import com.memoritta.server.security.JwtUtil;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -25,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.*;
 
 @SpringBootTest
-@ContextConfiguration(classes = {UserAccessManagerTest.Config.class, PasswordUtils.class, UserUtils.class, UserController.class, UserAccessManager.class})
+@ContextConfiguration(classes = {UserAccessManagerTest.Config.class, PasswordUtils.class, UserUtils.class, JwtUtil.class, UserController.class, UserAccessManager.class})
 class UserAccessManagerTest {
 
     @Autowired

--- a/server/src/test/java/com/memoritta/server/security/JwtUtilTest.java
+++ b/server/src/test/java/com/memoritta/server/security/JwtUtilTest.java
@@ -3,21 +3,19 @@ package com.memoritta.server.security;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@SpringBootTest
 class JwtUtilTest {
 
+    @Autowired
     private JwtUtil jwtUtil;
-
-    @BeforeEach
-    void setUp() {
-        jwtUtil = new JwtUtil();
-    }
 
     @Test
     void testGenerateAndExtractUsername() {

--- a/server/src/test/resources/application-test.properties
+++ b/server/src/test/resources/application-test.properties
@@ -1,2 +1,3 @@
 spring.security.user.name=admin
 spring.security.user.password=admin
+spring.security.oauth2.resourceserver.jwt.secret=Q+FQIAMDM+KevA+A3qnUiHO0eo27QB3tm2ahv3WqDlw=


### PR DESCRIPTION
## Summary
- generate JWT tokens using JwtUtil in user login
- enable JWT resource server security configuration
- remove placeholder JWT method
- configure secret in `application.yml`
- include `JwtUtil` in relevant test contexts

## Testing
- `mvn -q -pl server test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_683f5531a6a88327ad1047106e7d6f57