### PR TITLE
Add item tag search endpoint

### DIFF
--- a/server/src/main/java/com/memoritta/server/controller/ItemController.java
+++ b/server/src/main/java/com/memoritta/server/controller/ItemController.java
@@ -3,11 +3,13 @@ package com.memoritta.server.controller;
 import com.memoritta.server.manager.ItemManager;
 import com.memoritta.server.model.Item;
 import com.memoritta.server.model.SearchSimilarRequest;
+import com.memoritta.server.model.TagSearchRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.AllArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
 
 import java.io.IOException;
 import java.util.List;
@@ -93,6 +95,17 @@ public class ItemController {
             SearchSimilarRequest request
     ) {
         return itemManager.searchSimilarItems(request.getId());
+    }
+
+    @PostMapping("/items/tags")
+    @Operation(
+            summary = "Search items by tags",
+            description = "Returns a list of items filtered by tags. Set matchAll to true to require all tags or false to match at least one."
+    )
+    public List<Item> searchItemsByTags(
+            @RequestBody TagSearchRequest request
+    ) {
+        return itemManager.searchItemsByTags(request.getTags(), request.isMatchAll());
     }
 
 }

--- a/server/src/main/java/com/memoritta/server/dao/ItemDao.java
+++ b/server/src/main/java/com/memoritta/server/dao/ItemDao.java
@@ -1,6 +1,5 @@
 package com.memoritta.server.dao;
 
-import com.memoritta.server.model.Description;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -11,6 +10,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.Instant;
+import java.util.Map;
 import java.util.UUID;
 
 @Getter
@@ -22,6 +22,7 @@ public class ItemDao {
     private UUID id;
     private String name;
     private DescriptionDao description;
+    private Map<String, String> tags;
 
     @CreatedDate
     private Instant createdAt;

--- a/server/src/main/java/com/memoritta/server/model/Item.java
+++ b/server/src/main/java/com/memoritta/server/model/Item.java
@@ -4,6 +4,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.Map;
+
 import java.util.UUID;
 
 @Getter
@@ -13,4 +15,5 @@ public class Item {
     private UUID id;
     private String name;
     private Description description;
+    private Map<String, String> tags;
 }

--- a/server/src/main/java/com/memoritta/server/model/TagSearchRequest.java
+++ b/server/src/main/java/com/memoritta/server/model/TagSearchRequest.java
@@ -1,0 +1,15 @@
+package com.memoritta.server.model;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+public class TagSearchRequest {
+    private List<String> tags;
+    private boolean matchAll;
+}

--- a/server/src/test/java/com/memoritta/server/controller/ItemControllerTest.java
+++ b/server/src/test/java/com/memoritta/server/controller/ItemControllerTest.java
@@ -9,6 +9,7 @@ import com.memoritta.server.manager.ItemManager;
 import com.memoritta.server.mapper.ItemMapper;
 import com.memoritta.server.model.Item;
 import com.memoritta.server.model.SearchSimilarRequest;
+import com.memoritta.server.model.TagSearchRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -25,6 +26,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -135,6 +137,33 @@ class ItemControllerTest {
         assertEquals(id, result.get(0).getId());
 
         verify(itemRepository).findById(id);
+    }
+
+    @Test
+    void testSearchItemsByTags_shouldReturnMatchingItem() {
+        // Given
+        UUID beerId = UUID.randomUUID();
+        ItemDao beer = ItemDao.builder()
+                .id(beerId)
+                .tags(Map.of("category", "beer"))
+                .build();
+        ItemDao wine = ItemDao.builder()
+                .id(UUID.randomUUID())
+                .tags(Map.of("category", "wine"))
+                .build();
+        when(itemRepository.findAll()).thenReturn(List.of(beer, wine));
+
+        // When
+        TagSearchRequest request = TagSearchRequest.builder()
+                .tags(List.of("#category=beer"))
+                .matchAll(true)
+                .build();
+        List<Item> result = itemController.searchItemsByTags(request);
+
+        // Then
+        assertEquals(1, result.size());
+        assertEquals(beerId, result.get(0).getId());
+        verify(itemRepository).findAll();
     }
 
 }

--- a/server/src/test/java/integration/ItemTagsIT.java
+++ b/server/src/test/java/integration/ItemTagsIT.java
@@ -1,0 +1,34 @@
+package integration;
+
+import io.restassured.RestAssured;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.junit.jupiter.EnabledIf;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@Tag("integration")
+public class ItemTagsIT {
+
+    @EnabledIf(expression = "#{systemEnvironment['PROD'] == null}", reason = "Disabled in PROD environment")
+    @Test
+    void testSearchItemsByTags() {
+        RestAssured.baseURI = "http://localhost:9090";
+
+        var response = given()
+                .auth().basic("admin", "admin")
+                .contentType("application/json")
+                .body("{\"tags\":[\"#category=beer\"],\"matchAll\":true}")
+                .when()
+                .post("/items/tags")
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        assertThat(response.getBody()).isNotNull();
+    }
+}


### PR DESCRIPTION
## Summary
- extend `Item` and `ItemDao` with tag map
- add `searchItemsByTags` method in `ItemManager`
- expose `/items/tags` endpoint in `ItemController`
- unit test for tag searching
- e2e integration test skeleton using RestAssured

## Testing
- `mvn -q -DskipITs=false verify` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_683f5ad7c6008327a01b76a9f2c1c76f