### PR TITLE
Add GitHub Actions workflow for integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,76 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    services:
+      mongo:
+        image: mongo:7
+        ports:
+          - 27017:27017
+        env:
+          MONGO_INITDB_ROOT_USERNAME: user
+          MONGO_INITDB_ROOT_PASSWORD: qazxsw123
+          MONGO_INITDB_DATABASE: yapp-db
+        options: >-
+          --health-cmd "mongosh --eval 'db.runCommand(\"ping\")'" --health-interval 10s --health-timeout 5s --health-retries 5
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+        command: redis-server --requirepass qazxsw123
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build
+
+      - name: Build server
+        run: mvn -B -pl server -am package
+
+      - name: Start server
+        run: |
+          java -jar server/target/server-1.0-SNAPSHOT.jar &
+          echo $! > server.pid
+
+      - name: Wait for server
+        run: |
+          for i in {1..30}; do
+            if curl -s http://localhost:9090/actuator/health >/dev/null; then
+              echo "Server is up"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "Server failed to start" && cat server.pid && exit 1
+
+      - name: Run integration tests
+        run: mvn -B -pl server -Dtest=*IT test
+
+      - name: Stop server
+        if: always()
+        run: |
+          kill $(cat server.pid) || true


### PR DESCRIPTION
## Summary
- add Integration Tests workflow for frontend & backend

## Testing
- `npm test` *(fails: Missing script)*
- `mvn -pl server test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68403a6eabd88327a20989f9652e3242