### PR TITLE
Fix integration workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,7 +25,6 @@ jobs:
           - 6379:6379
         options: >-
           --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
-        command: redis-server --requirepass qazxsw123
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- remove unsupported `command` field from Redis service container

## Testing
- `node --version`
- `mvn -q -pl server -DskipTests help:evaluate -Dexpression=project.version` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68434a36cb548327ac6257fddecc6456