### PR TITLE
Add buttons after login

### DIFF
--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -59,6 +59,15 @@ export default function LoginForm() {
             <li>Email: {userInfo.email}</li>
             <li>ID: {userInfo.id}</li>
           </ul>
+          <div>
+            <button>Add</button>
+          </div>
+          <div>
+            <button>Check</button>
+          </div>
+          <div>
+            <button>Inspiration</button>
+          </div>
         </div>
       )}
     </form>

--- a/frontend/src/LoginForm.test.jsx
+++ b/frontend/src/LoginForm.test.jsx
@@ -43,6 +43,9 @@ describe('LoginForm', () => {
       expect(screen.getByText(/Nickname: Nick/)).toBeInTheDocument();
       expect(screen.getByText(/Email: user@example.com/)).toBeInTheDocument();
       expect(screen.getByText(/ID: 1/)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Add' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Check' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Inspiration' })).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary
- show Add, Check and Inspiration buttons after successful login
- update tests to check for buttons

## Testing
- `npm --prefix frontend test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68455f5765dc8327a16212ef87b8d900