### PR TITLE
Update post-login navigation

### DIFF
--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -1,5 +1,11 @@
 import React, { useState } from 'react';
 
+import AddView from './AddView.jsx';
+import Compare from './Compare.jsx';
+import Ask from './Ask.jsx';
+import Questions from './Questions.jsx';
+import Friends from './Friends.jsx';
+
 import { BACKEND_URL } from './config.js';
 
 export default function LoginForm() {
@@ -7,6 +13,7 @@ export default function LoginForm() {
   const [password, setPassword] = useState('');
   const [message, setMessage] = useState('');
   const [userInfo, setUserInfo] = useState(null);
+  const [currentView, setCurrentView] = useState(null);
 
   async function handleSubmit(e) {
     e.preventDefault();
@@ -60,14 +67,25 @@ export default function LoginForm() {
             <li>ID: {userInfo.id}</li>
           </ul>
           <div>
-            <button>Add</button>
+            <button onClick={() => setCurrentView('add')}>Add</button>
           </div>
           <div>
-            <button>Check</button>
+            <button onClick={() => setCurrentView('compare')}>Compare</button>
           </div>
           <div>
-            <button>Inspiration</button>
+            <button onClick={() => setCurrentView('ask')}>Ask</button>
           </div>
+          <div>
+            <button onClick={() => setCurrentView('questions')}>Questions</button>
+          </div>
+          <div>
+            <button onClick={() => setCurrentView('friends')}>Friends</button>
+          </div>
+          {currentView === 'add' && <AddView />}
+          {currentView === 'compare' && <Compare />}
+          {currentView === 'ask' && <Ask />}
+          {currentView === 'questions' && <Questions />}
+          {currentView === 'friends' && <Friends />}
         </div>
       )}
     </form>

--- a/frontend/src/LoginForm.test.jsx
+++ b/frontend/src/LoginForm.test.jsx
@@ -44,8 +44,49 @@ describe('LoginForm', () => {
       expect(screen.getByText(/Email: user@example.com/)).toBeInTheDocument();
       expect(screen.getByText(/ID: 1/)).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Add' })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Check' })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Inspiration' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Compare' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Ask' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Questions' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Friends' })).toBeInTheDocument();
+    });
+  });
+
+  it('shows proper view when a button is clicked', async () => {
+    const mockResponse = {
+      user: { nickname: 'Nick', email: 'user@example.com', id: '1' },
+      jwtToken: 'token',
+    };
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      })
+    );
+
+    render(<LoginForm />);
+    fireEvent.change(screen.getByTestId('email-input'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.change(screen.getByTestId('password-input'), {
+      target: { value: 'secret' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+
+    await waitFor(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+      expect(screen.getByRole('heading', { name: 'Add' })).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Compare' }));
+      expect(screen.getByRole('heading', { name: 'Compare' })).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Ask' }));
+      expect(screen.getByRole('heading', { name: 'Ask' })).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Questions' }));
+      expect(screen.getByRole('heading', { name: 'Questions' })).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Friends' }));
+      expect(screen.getByRole('heading', { name: 'Friends' })).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary
- show buttons for Add, Compare, Ask, Questions and Friends after login
- add simple view switching logic
- update unit tests for new buttons and views

## Testing
- `npm --prefix frontend exec vitest run` *(fails: Cannot run all tests due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_684568cf50c4832791857d8a564203da