### PR TITLE
Add camera feature to Add view

### DIFF
--- a/frontend/src/AddView.jsx
+++ b/frontend/src/AddView.jsx
@@ -1,9 +1,56 @@
-import React from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 
 export default function AddView() {
+  const [stream, setStream] = useState(null);
+  const [photo, setPhoto] = useState(null);
+  const videoRef = useRef(null);
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    if (videoRef.current && stream) {
+      // Attach the stream to the video element
+      // JSDOM will just store this property
+      videoRef.current.srcObject = stream;
+    }
+  }, [stream]);
+
+  async function handleEnableCamera() {
+    if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+      return;
+    }
+    try {
+      const userStream = await navigator.mediaDevices.getUserMedia({ video: true });
+      setStream(userStream);
+    } catch (err) {
+      // Ignore errors for now
+    }
+  }
+
+  function handleTakePhoto() {
+    const video = videoRef.current;
+    const canvas = canvasRef.current;
+    if (!video || !canvas) {
+      return;
+    }
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(video, 0, 0);
+    setPhoto(canvas.toDataURL('image/png'));
+  }
+
   return (
     <div>
       <h1>Add</h1>
+      {!stream && <button onClick={handleEnableCamera}>Enable Camera</button>}
+      {stream && (
+        <div>
+          <video ref={videoRef} autoPlay playsInline />
+          <button onClick={handleTakePhoto}>Take Photo</button>
+        </div>
+      )}
+      <canvas ref={canvasRef} style={{ display: 'none' }} />
+      {photo && <img src={photo} alt="Captured" />}
     </div>
   );
 }

--- a/frontend/src/AddView.test.jsx
+++ b/frontend/src/AddView.test.jsx
@@ -1,10 +1,27 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
 import AddView from './AddView.jsx';
 
 describe('AddView', () => {
   it('shows Add title', () => {
     render(<AddView />);
     expect(screen.getByRole('heading', { name: 'Add' })).toBeInTheDocument();
+  });
+
+  it('enables camera and shows take photo button', async () => {
+    global.navigator.mediaDevices = {
+      getUserMedia: vi.fn(() => Promise.resolve('stream')),
+    };
+
+    render(<AddView />);
+
+    const enableBtn = screen.getByRole('button', { name: /enable camera/i });
+    fireEvent.click(enableBtn);
+
+    await waitFor(() => {
+      expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({ video: true });
+      expect(screen.getByRole('button', { name: /take photo/i })).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- enable camera access and picture capture in Add view
- test that camera can be enabled and a photo button appears

## Testing
- `npm test --silent --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68456a4a538c8327b8b9a120dffb53bf