### PR TITLE
Add barcode scanning hook to frontend

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -17,3 +17,6 @@ Visit `http://localhost:5173` in your browser to see the running application.
 
 ### Configuration
 Change the backend API address in `src/config.js` if your server runs on a different host or port.
+
+### Barcode Scanning
+This app ships with a custom React hook `useBarcodeScanner`. It uses the `@zxing/browser` library to read barcodes from the camera. The hook is not used yet but you can import it and render a `video` element with the provided `ref` when you want to scan codes.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@zxing/browser": "^0.1.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -1558,6 +1559,41 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@zxing/browser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@zxing/browser/-/browser-0.1.5.tgz",
+      "integrity": "sha512-4Lmrn/il4+UNb87Gk8h1iWnhj39TASEHpd91CwwSJtY5u+wa0iH9qS0wNLAWbNVYXR66WmT5uiMhZ7oVTrKfxw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@zxing/text-encoding": "^0.9.0"
+      },
+      "peerDependencies": {
+        "@zxing/library": "^0.21.0"
+      }
+    },
+    "node_modules/@zxing/library": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.21.3.tgz",
+      "integrity": "sha512-hZHqFe2JyH/ZxviJZosZjV+2s6EDSY0O24R+FQmlWZBZXP9IqMo7S3nb3+2LBWxodJQkSurdQGnqE7KXqrYgow==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ts-custom-error": "^3.2.1"
+      },
+      "engines": {
+        "node": ">= 10.4.0"
+      },
+      "optionalDependencies": {
+        "@zxing/text-encoding": "~0.9.0"
+      }
+    },
+    "node_modules/@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "license": "(Unlicense OR Apache-2.0)",
+      "optional": true
     },
     "node_modules/agent-base": {
       "version": "7.1.3",
@@ -3551,6 +3587,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/ts-custom-error": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
+      "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "@zxing/browser": "^0.1.5"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.0",

--- a/frontend/src/hooks/useBarcodeScanner.js
+++ b/frontend/src/hooks/useBarcodeScanner.js
@@ -1,0 +1,35 @@
+import { useRef, useState } from 'react';
+import { BrowserMultiFormatReader } from '@zxing/browser';
+
+export default function useBarcodeScanner() {
+  const videoRef = useRef(null);
+  const [barcode, setBarcode] = useState(null);
+  const [scanning, setScanning] = useState(false);
+  const readerRef = useRef(null);
+
+  async function start() {
+    if (scanning) return;
+    setScanning(true);
+    const reader = new BrowserMultiFormatReader();
+    readerRef.current = reader;
+    try {
+      await reader.decodeFromVideoDevice(null, videoRef.current, (result, err) => {
+        if (result) {
+          setBarcode(result.getText());
+        }
+      });
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  function stop() {
+    if (readerRef.current) {
+      readerRef.current.reset();
+      readerRef.current = null;
+    }
+    setScanning(false);
+  }
+
+  return { videoRef, barcode, scanning, start, stop };
+}

--- a/frontend/src/hooks/useBarcodeScanner.test.js
+++ b/frontend/src/hooks/useBarcodeScanner.test.js
@@ -1,0 +1,35 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi } from 'vitest';
+import useBarcodeScanner from './useBarcodeScanner.js';
+import { BrowserMultiFormatReader } from '@zxing/browser';
+
+vi.mock('@zxing/browser', () => {
+  return {
+    BrowserMultiFormatReader: vi.fn().mockImplementation(() => ({
+      decodeFromVideoDevice: vi.fn((deviceId, video, cb) => {
+        cb({ getText: () => '123456' }, null);
+        return Promise.resolve();
+      }),
+      reset: vi.fn(),
+    })),
+  };
+});
+
+describe('useBarcodeScanner', () => {
+  it('reads barcode from camera', async () => {
+    const { result } = renderHook(() => useBarcodeScanner());
+    await act(async () => {
+      await result.current.start();
+    });
+    expect(result.current.barcode).toBe('123456');
+    expect(result.current.scanning).toBe(true);
+  });
+
+  it('stops scanning', () => {
+    const { result } = renderHook(() => useBarcodeScanner());
+    act(() => {
+      result.current.stop();
+    });
+    expect(result.current.scanning).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add ZXing library for barcode scanning
- implement `useBarcodeScanner` hook
- document scanning in README
- test the new hook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68456b585c0c8327a61c47566a7af423