### PR TITLE
Hide login form after success

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,11 +1,13 @@
-import React from 'react';
+import React, { useState } from 'react';
 import LoginForm from './LoginForm.jsx';
 
 export default function App() {
+  const [userInfo, setUserInfo] = useState(null);
+
   return (
     <div>
-      <h1>Login</h1>
-      <LoginForm />
+      <h1>{userInfo ? `Welcome ${userInfo.nickname}` : 'Login'}</h1>
+      <LoginForm onLogin={setUserInfo} />
     </div>
   );
 }

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import App from './App.jsx';
+import { BACKEND_URL } from './config.js';
+
+describe('App login flow', () => {
+  it('changes title after successful login', async () => {
+    const mockResponse = {
+      user: { nickname: 'nickname1', email: 'user@example.com', id: '1' },
+      jwtToken: 'token',
+    };
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      })
+    );
+
+    render(<App />);
+
+    fireEvent.change(screen.getByTestId('email-input'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.change(screen.getByTestId('password-input'), {
+      target: { value: 'secret' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Welcome nickname1' })).toBeInTheDocument();
+      expect(screen.queryByTestId('email-input')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import { BACKEND_URL } from './config.js';
 
-export default function LoginForm() {
+export default function LoginForm({ onLogin }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [message, setMessage] = useState('');
@@ -22,8 +22,10 @@ export default function LoginForm() {
         throw new Error('login failed');
       }
       const data = await response.json();
-      setMessage(`Welcome ${data.user.nickname}`);
       setUserInfo(data.user);
+      if (onLogin) {
+        onLogin(data.user);
+      }
     } catch (err) {
       setMessage('Login error');
     }
@@ -31,26 +33,30 @@ export default function LoginForm() {
 
   return (
     <form className="login-form" onSubmit={handleSubmit}>
-      <label>
-        Email
-        <input
-          data-testid="email-input"
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-        />
-      </label>
-      <label>
-        Password
-        <input
-          data-testid="password-input"
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-      </label>
-      <button type="submit">Login</button>
-      {message && <p>{message}</p>}
+      {!userInfo && (
+        <>
+          <label>
+            Email
+            <input
+              data-testid="email-input"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+          </label>
+          <label>
+            Password
+            <input
+              data-testid="password-input"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          </label>
+          <button type="submit">Login</button>
+          {message && !userInfo && <p>{message}</p>}
+        </>
+      )}
       {userInfo && (
         <div>
           <h2>User Info</h2>

--- a/frontend/src/LoginForm.test.jsx
+++ b/frontend/src/LoginForm.test.jsx
@@ -13,7 +13,7 @@ describe('LoginForm', () => {
 
   it('calls fetch with credentials and shows user info', async () => {
     const mockResponse = {
-      user: { nickname: 'Nick', email: 'user@example.com', id: '1' },
+      user: { nickname: 'nickname1', email: 'user@example.com', id: '1' },
       jwtToken: 'token',
     };
     global.fetch = vi.fn(() =>
@@ -40,7 +40,9 @@ describe('LoginForm', () => {
           method: 'POST',
         })
       );
-      expect(screen.getByText(/Nickname: Nick/)).toBeInTheDocument();
+      expect(screen.queryByTestId('email-input')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('password-input')).not.toBeInTheDocument();
+      expect(screen.getByText(/Nickname: nickname1/)).toBeInTheDocument();
       expect(screen.getByText(/Email: user@example.com/)).toBeInTheDocument();
       expect(screen.getByText(/ID: 1/)).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Add' })).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- update `App` to show dynamic title and pass login info
- hide the email and password fields once logged in
- add new test for `App` login flow
- update existing login form test

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68456acc7ab88327afaa2f4015c8ddf5