### PR TITLE
Add path filtering for CI workflows

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,0 +1,28 @@
+name: Frontend Tests
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-tests.yml'
+  pull_request:
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-tests.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+      - name: Run tests
+        working-directory: frontend
+        run: npm test -- --run

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,7 +3,15 @@ name: Integration Tests
 on:
   push:
     branches: [ main ]
+    paths:
+      - 'server/**'
+      - 'pom.xml'
+      - '.github/workflows/integration.yml'
   pull_request:
+    paths:
+      - 'server/**'
+      - 'pom.xml'
+      - '.github/workflows/integration.yml'
 
 jobs:
   build-test:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,8 +11,16 @@ name: Java CI with Maven
 on:
   push:
     branches: [ "main" ]
+    paths:
+      - 'server/**'
+      - 'pom.xml'
+      - '.github/workflows/maven.yml'
   pull_request:
     branches: [ "main" ]
+    paths:
+      - 'server/**'
+      - 'pom.xml'
+      - '.github/workflows/maven.yml'
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- add a dedicated workflow for frontend tests
- run Maven workflow only when server files change
- run integration tests only when backend files change

## Testing
- `npm test -- --run` in `frontend`
- `mvn -B -pl server -am test` *(fails: could not download parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68458f9f3a54832780ecc8245ff3a261