### PR TITLE
Add remember-me cookies for login

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -18,5 +18,9 @@ Visit `http://localhost:5173` in your browser to see the running application.
 ### Configuration
 Change the backend API address in `src/config.js` if your server runs on a different host or port.
 
+### Login Cookies
+The login form has a **Remember me** option. When checked, the app stores your
+email and password in browser cookies so the inputs are pre-filled next time.
+
 ### Barcode Scanning
 This app ships with a custom React hook `useBarcodeScanner`. It uses the `@zxing/browser` library to read barcodes from the camera. The hook is not used yet but you can import it and render a `video` element with the provided `ref` when you want to scan codes.

--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import AddView from './AddView.jsx';
 import Compare from './Compare.jsx';
@@ -11,9 +11,22 @@ import { BACKEND_URL } from './config.js';
 export default function LoginForm({ onLogin }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [remember, setRemember] = useState(false);
   const [message, setMessage] = useState('');
   const [userInfo, setUserInfo] = useState(null);
   const [currentView, setCurrentView] = useState(null);
+
+  useEffect(() => {
+    const matchEmail = document.cookie.match(/(?:^|;)\s*email=([^;]+)/);
+    const matchPassword = document.cookie.match(/(?:^|;)\s*password=([^;]+)/);
+    if (matchEmail) {
+      setEmail(decodeURIComponent(matchEmail[1]));
+      setRemember(true);
+    }
+    if (matchPassword) {
+      setPassword(decodeURIComponent(matchPassword[1]));
+    }
+  }, []);
 
   async function handleSubmit(e) {
     e.preventDefault();
@@ -30,6 +43,13 @@ export default function LoginForm({ onLogin }) {
       }
       const data = await response.json();
       setUserInfo(data.user);
+      if (remember) {
+        document.cookie = `email=${encodeURIComponent(email)}; path=/`;
+        document.cookie = `password=${encodeURIComponent(password)}; path=/`;
+      } else {
+        document.cookie = 'email=; Max-Age=0; path=/';
+        document.cookie = 'password=; Max-Age=0; path=/';
+      }
       if (onLogin) {
         onLogin(data.user);
       }
@@ -59,6 +79,15 @@ export default function LoginForm({ onLogin }) {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
             />
+          </label>
+          <label>
+            <input
+              data-testid="remember-checkbox"
+              type="checkbox"
+              checked={remember}
+              onChange={(e) => setRemember(e.target.checked)}
+            />
+            Remember me
           </label>
           <button type="submit">Login</button>
           {message && !userInfo && <p>{message}</p>}

--- a/frontend/src/LoginForm.test.jsx
+++ b/frontend/src/LoginForm.test.jsx
@@ -9,6 +9,7 @@ describe('LoginForm', () => {
     render(<LoginForm />);
     expect(screen.getByTestId('email-input')).toBeInTheDocument();
     expect(screen.getByTestId('password-input')).toBeInTheDocument();
+    expect(screen.getByTestId('remember-checkbox')).toBeInTheDocument();
   });
 
   it('calls fetch with credentials and shows user info', async () => {
@@ -51,6 +52,42 @@ describe('LoginForm', () => {
       expect(screen.getByRole('button', { name: 'Questions' })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Friends' })).toBeInTheDocument();
     });
+  });
+
+  it('stores credentials in cookies when remember is checked', async () => {
+    const mockResponse = {
+      user: { nickname: 'name', email: 'user@example.com', id: '1' },
+      jwtToken: 'token',
+    };
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      })
+    );
+
+    render(<LoginForm />);
+    fireEvent.change(screen.getByTestId('email-input'), {
+      target: { value: 'user@example.com' },
+    });
+    fireEvent.change(screen.getByTestId('password-input'), {
+      target: { value: 'secret' },
+    });
+    fireEvent.click(screen.getByTestId('remember-checkbox'));
+    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+
+    await waitFor(() => {
+      expect(document.cookie).toMatch(/email=user%40example.com/);
+      expect(document.cookie).toMatch(/password=secret/);
+    });
+  });
+
+  it('prefills inputs from cookies on load', () => {
+    document.cookie = 'email=foo%40example.com';
+    document.cookie = 'password=bar';
+    render(<LoginForm />);
+    expect(screen.getByTestId('email-input')).toHaveValue('foo@example.com');
+    expect(screen.getByTestId('password-input')).toHaveValue('bar');
   });
 
   it('shows proper view when a button is clicked', async () => {


### PR DESCRIPTION
## Summary
- store login credentials in cookies when 'Remember me' is checked
- load email and password from cookies when login form mounts
- document cookies feature in README
- test cookie behavior in LoginForm tests

## Testing
- `npm install --silent`
- `npm test --silent` *(fails: close timed out after 10000ms but all tests passed)*
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a197118083278cea6efc26681e26