### PR TITLE
Add back navigation button to views

### DIFF
--- a/frontend/src/AddView.jsx
+++ b/frontend/src/AddView.jsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState, useEffect } from 'react';
 
-export default function AddView() {
+export default function AddView({ onBack = () => {} }) {
   const [stream, setStream] = useState(null);
   const [photo, setPhoto] = useState(null);
   const videoRef = useRef(null);
@@ -40,7 +40,10 @@ export default function AddView() {
   }
 
   return (
-    <div>
+    <div style={{ position: 'relative' }}>
+      <button className="back-button" onClick={onBack}>
+        Back
+      </button>
       <h1>Add</h1>
       {!stream && <button onClick={handleEnableCamera}>Enable Camera</button>}
       {stream && (

--- a/frontend/src/AddView.test.jsx
+++ b/frontend/src/AddView.test.jsx
@@ -7,6 +7,7 @@ describe('AddView', () => {
   it('shows Add title', () => {
     render(<AddView />);
     expect(screen.getByRole('heading', { name: 'Add' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
   });
 
   it('enables camera and shows take photo button', async () => {

--- a/frontend/src/Ask.jsx
+++ b/frontend/src/Ask.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 
-export default function Ask() {
+export default function Ask({ onBack = () => {} }) {
   return (
-    <div>
+    <div style={{ position: 'relative' }}>
+      <button className="back-button" onClick={onBack}>
+        Back
+      </button>
       <h1>Ask</h1>
     </div>
   );

--- a/frontend/src/Ask.test.jsx
+++ b/frontend/src/Ask.test.jsx
@@ -6,5 +6,6 @@ describe('Ask view', () => {
   it('shows the Ask title', () => {
     render(<Ask />);
     expect(screen.getByRole('heading', { name: 'Ask' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
   });
 });

--- a/frontend/src/Compare.jsx
+++ b/frontend/src/Compare.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 
-export default function Compare() {
+export default function Compare({ onBack = () => {} }) {
   return (
-    <div>
+    <div style={{ position: 'relative' }}>
+      <button className="back-button" onClick={onBack}>
+        Back
+      </button>
       <h1>Compare</h1>
     </div>
   );

--- a/frontend/src/Compare.test.jsx
+++ b/frontend/src/Compare.test.jsx
@@ -6,5 +6,6 @@ describe('Compare', () => {
   it('shows Compare title', () => {
     render(<Compare />);
     expect(screen.getByRole('heading', { name: 'Compare' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
   });
 });

--- a/frontend/src/Friends.jsx
+++ b/frontend/src/Friends.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 
-export default function Friends() {
+export default function Friends({ onBack = () => {} }) {
   return (
-    <div>
+    <div style={{ position: 'relative' }}>
+      <button className="back-button" onClick={onBack}>
+        Back
+      </button>
       <h1>Friends</h1>
     </div>
   );

--- a/frontend/src/Friends.test.jsx
+++ b/frontend/src/Friends.test.jsx
@@ -6,5 +6,6 @@ describe('Friends component', () => {
   it('shows title', () => {
     render(<Friends />);
     expect(screen.getByRole('heading', { level: 1, name: 'Friends' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
   });
 });

--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -95,32 +95,46 @@ export default function LoginForm({ onLogin }) {
       )}
       {userInfo && (
         <div>
-          <h2>User Info</h2>
-          <ul>
-            <li>Nickname: {userInfo.nickname}</li>
-            <li>Email: {userInfo.email}</li>
-            <li>ID: {userInfo.id}</li>
-          </ul>
-          <div>
-            <button onClick={() => setCurrentView('add')}>Add</button>
-          </div>
-          <div>
-            <button onClick={() => setCurrentView('compare')}>Compare</button>
-          </div>
-          <div>
-            <button onClick={() => setCurrentView('ask')}>Ask</button>
-          </div>
-          <div>
-            <button onClick={() => setCurrentView('questions')}>Questions</button>
-          </div>
-          <div>
-            <button onClick={() => setCurrentView('friends')}>Friends</button>
-          </div>
-          {currentView === 'add' && <AddView />}
-          {currentView === 'compare' && <Compare />}
-          {currentView === 'ask' && <Ask />}
-          {currentView === 'questions' && <Questions />}
-          {currentView === 'friends' && <Friends />}
+          {currentView === null && (
+            <>
+              <h2>User Info</h2>
+              <ul>
+                <li>Nickname: {userInfo.nickname}</li>
+                <li>Email: {userInfo.email}</li>
+                <li>ID: {userInfo.id}</li>
+              </ul>
+              <div>
+                <button onClick={() => setCurrentView('add')}>Add</button>
+              </div>
+              <div>
+                <button onClick={() => setCurrentView('compare')}>Compare</button>
+              </div>
+              <div>
+                <button onClick={() => setCurrentView('ask')}>Ask</button>
+              </div>
+              <div>
+                <button onClick={() => setCurrentView('questions')}>Questions</button>
+              </div>
+              <div>
+                <button onClick={() => setCurrentView('friends')}>Friends</button>
+              </div>
+            </>
+          )}
+          {currentView === 'add' && (
+            <AddView onBack={() => setCurrentView(null)} />
+          )}
+          {currentView === 'compare' && (
+            <Compare onBack={() => setCurrentView(null)} />
+          )}
+          {currentView === 'ask' && (
+            <Ask onBack={() => setCurrentView(null)} />
+          )}
+          {currentView === 'questions' && (
+            <Questions onBack={() => setCurrentView(null)} />
+          )}
+          {currentView === 'friends' && (
+            <Friends onBack={() => setCurrentView(null)} />
+          )}
         </div>
       )}
     </form>

--- a/frontend/src/LoginForm.test.jsx
+++ b/frontend/src/LoginForm.test.jsx
@@ -121,23 +121,24 @@ describe('LoginForm', () => {
 
       fireEvent.click(screen.getByRole('button', { name: 'Add' }));
       await screen.findByRole('heading', { name: 'Add' });
-      console.log('.');
-
+      expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+      await screen.findByRole('button', { name: 'Compare' });
       fireEvent.click(screen.getByRole('button', { name: 'Compare' }));
       await screen.findByRole('heading', { name: 'Compare' });
-      console.log('.');
-
+      fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+      await screen.findByRole('button', { name: 'Ask' });
       fireEvent.click(screen.getByRole('button', { name: 'Ask' }));
       await screen.findByRole('heading', { name: 'Ask' });
-      console.log('.');
-
+      fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+      await screen.findByRole('button', { name: 'Questions' });
       fireEvent.click(screen.getByRole('button', { name: 'Questions' }));
       await screen.findByRole('heading', { name: 'Questions' });
-      console.log('.');
-
+      fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+      await screen.findByRole('button', { name: 'Friends' });
       fireEvent.click(screen.getByRole('button', { name: 'Friends' }));
       await screen.findByRole('heading', { name: 'Friends' });
-      console.log('.');
+      fireEvent.click(screen.getByRole('button', { name: 'Back' }));
     }
   );
 });

--- a/frontend/src/Questions.jsx
+++ b/frontend/src/Questions.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 
-export default function Questions() {
+export default function Questions({ onBack = () => {} }) {
   return (
-    <div>
+    <div style={{ position: 'relative' }}>
+      <button className="back-button" onClick={onBack}>
+        Back
+      </button>
       <h1>Questions</h1>
     </div>
   );

--- a/frontend/src/Questions.test.jsx
+++ b/frontend/src/Questions.test.jsx
@@ -6,5 +6,6 @@ describe('Questions view', () => {
   it('shows Questions title', () => {
     render(<Questions />);
     expect(screen.getByRole('heading', { name: 'Questions' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
   });
 });

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -25,3 +25,9 @@ h1 {
     box-sizing: border-box;
   }
 }
+
+.back-button {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- hide user info while viewing pages
- add `Back` button to each page
- style `Back` button in top-right corner
- update unit tests

## Testing
- `npm test --silent -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6845b47b3fc8832781eaee1186eaafd8