### PR TITLE
Add Ask view input area

### DIFF
--- a/frontend/src/Ask.jsx
+++ b/frontend/src/Ask.jsx
@@ -1,9 +1,22 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 export default function Ask() {
+  const [question, setQuestion] = useState('');
+
+  function handleAsk() {
+    // Add API call or other logic here later
+  }
+
   return (
     <div>
       <h1>Ask</h1>
+      <textarea
+        data-testid="ask-textarea"
+        rows={5}
+        value={question}
+        onChange={(e) => setQuestion(e.target.value)}
+      />
+      <button onClick={handleAsk}>Ask</button>
     </div>
   );
 }

--- a/frontend/src/Ask.test.jsx
+++ b/frontend/src/Ask.test.jsx
@@ -7,4 +7,10 @@ describe('Ask view', () => {
     render(<Ask />);
     expect(screen.getByRole('heading', { name: 'Ask' })).toBeInTheDocument();
   });
+
+  it('shows a textarea and Ask button', () => {
+    render(<Ask />);
+    expect(screen.getByTestId('ask-textarea')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Ask' })).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- update `Ask.jsx` to include textarea and button
- cover new Ask view UI with tests

## Testing
- `npm test --silent -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6845b4e8356083278da8986c80fcd76d