### PR TITLE
Add questions list view

### DIFF
--- a/frontend/src/Questions.jsx
+++ b/frontend/src/Questions.jsx
@@ -1,9 +1,30 @@
 import React from 'react';
 
+const sampleQuestions = [
+  'How can we optimize the database queries for better performance?',
+  'What is the expected release date for version 2.0 of our product?',
+  'Which new frameworks should we evaluate for the frontend redesign?'
+];
+
+function truncate(str, max) {
+  if (str.length <= max) {
+    return str;
+  }
+  return `${str.slice(0, max - 3)}...`;
+}
+
 export default function Questions() {
+  const maxChars = Math.floor(window.innerWidth / 10);
   return (
     <div>
       <h1>Questions</h1>
+      <ul>
+        {sampleQuestions.map((q, i) => (
+          <li key={i} className="question-item">
+            {truncate(q, maxChars)}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/frontend/src/Questions.test.jsx
+++ b/frontend/src/Questions.test.jsx
@@ -7,4 +7,12 @@ describe('Questions view', () => {
     render(<Questions />);
     expect(screen.getByRole('heading', { name: 'Questions' })).toBeInTheDocument();
   });
+
+  it('renders truncated questions list', () => {
+    window.innerWidth = 80;
+    render(<Questions />);
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(3);
+    expect(items.some((li) => li.textContent.endsWith('...'))).toBe(true);
+  });
 });

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -25,3 +25,9 @@ h1 {
     box-sizing: border-box;
   }
 }
+
+.question-item {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}


### PR DESCRIPTION
## Summary
- add a sample list of questions to the Questions view
- trim the questions to window width
- show ellipsis via new CSS class
- test that Questions renders a truncated list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845b52fe7448327b26929d4883ec73f