### PR TITLE
Separate Welcome heading and nickname

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,7 +6,14 @@ export default function App() {
 
   return (
     <div>
-      <h1>{userInfo ? `Welcome ${userInfo.nickname}` : 'Login'}</h1>
+      {userInfo ? (
+        <>
+          <h1>Welcome</h1>
+          <p data-testid="user-nickname">{userInfo.nickname}</p>
+        </>
+      ) : (
+        <h1>Login</h1>
+      )}
       <LoginForm onLogin={setUserInfo} />
     </div>
   );

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -28,7 +28,8 @@ describe('App login flow', () => {
     fireEvent.click(screen.getByRole('button', { name: /login/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Welcome nickname1' })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'Welcome' })).toBeInTheDocument();
+      expect(screen.getByTestId('user-nickname')).toHaveTextContent('nickname1');
       expect(screen.queryByTestId('email-input')).not.toBeInTheDocument();
     });
   });


### PR DESCRIPTION
## Summary
- modify the Welcome screen to show the user's nickname on a new line
- update tests for the new markup

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845b5a29ac8832780f007049da1b492