### PR TITLE
Fix Ask view prop causing test hang

### DIFF
--- a/frontend/src/Ask.jsx
+++ b/frontend/src/Ask.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-export default function Ask() {
+export default function Ask({ onBack = () => {} }) {
   const [question, setQuestion] = useState('');
 
   function handleAsk() {


### PR DESCRIPTION
## Summary
- accept `onBack` prop in `Ask` view with a default function
- all frontend tests pass now

## Testing
- `npm install --loglevel error`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6845b87311b0832797ab8f76ea69cd8c