### PR TITLE
Remove global welcome banner, add headers

### DIFF
--- a/frontend/src/AddView.jsx
+++ b/frontend/src/AddView.jsx
@@ -40,11 +40,13 @@ export default function AddView({ onBack = () => {} }) {
   }
 
   return (
-    <div style={{ position: 'relative' }}>
-      <button className="back-button" onClick={onBack}>
-        Back
-      </button>
-      <h1>Add</h1>
+    <div>
+      <div className="view-header">
+        <h1>Add</h1>
+        <button className="back-button" onClick={onBack}>
+          Back
+        </button>
+      </div>
       {!stream && <button onClick={handleEnableCamera}>Enable Camera</button>}
       <div className="camera-window">
         {stream ? (

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,20 +1,10 @@
-import React, { useState } from 'react';
+import React from 'react';
 import LoginForm from './LoginForm.jsx';
 
 export default function App() {
-  const [userInfo, setUserInfo] = useState(null);
-
   return (
     <div>
-      {userInfo ? (
-        <>
-          <h1>Welcome</h1>
-          <p data-testid="user-nickname">{userInfo.nickname}</p>
-        </>
-      ) : (
-        <h1>Login</h1>
-      )}
-      <LoginForm onLogin={setUserInfo} />
+      <LoginForm />
     </div>
   );
 }

--- a/frontend/src/Ask.jsx
+++ b/frontend/src/Ask.jsx
@@ -7,11 +7,11 @@ export default function Ask({ onBack = () => {} }) {
     // Add API call or other logic here later
   }
   return (
-    <div style={{ position: 'relative' }}>
-      <button className="back-button" onClick={onBack}>
-        Back
-      </button>
-      <h1>Ask</h1>
+    <div>
+      <div className="view-header">
+        <h1>Ask</h1>
+        <button className="back-button" onClick={onBack}>Back</button>
+      </div>
       <textarea
         data-testid="ask-textarea"
         rows={5}

--- a/frontend/src/Compare.jsx
+++ b/frontend/src/Compare.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 
 export default function Compare({ onBack = () => {} }) {
   return (
-    <div style={{ position: 'relative' }}>
-      <button className="back-button" onClick={onBack}>
-        Back
-      </button>
-      <h1>Compare</h1>
+    <div>
+      <div className="view-header">
+        <h1>Compare</h1>
+        <button className="back-button" onClick={onBack}>Back</button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/Friends.jsx
+++ b/frontend/src/Friends.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 
 export default function Friends({ onBack = () => {} }) {
   return (
-    <div style={{ position: 'relative' }}>
-      <button className="back-button" onClick={onBack}>
-        Back
-      </button>
-      <h1>Friends</h1>
+    <div>
+      <div className="view-header">
+        <h1>Friends</h1>
+        <button className="back-button" onClick={onBack}>Back</button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -62,6 +62,7 @@ export default function LoginForm({ onLogin }) {
     <form className="login-form" onSubmit={handleSubmit}>
       {!userInfo && (
         <>
+          <h1>Login</h1>
           <label>
             Email
             <input
@@ -97,6 +98,8 @@ export default function LoginForm({ onLogin }) {
         <div>
           {currentView === null && (
             <>
+              <h1>Welcome</h1>
+              <p data-testid="user-nickname">{userInfo.nickname}</p>
               <h2>User Info</h2>
               <ul>
                 <li>Nickname: {userInfo.nickname}</li>

--- a/frontend/src/Questions.jsx
+++ b/frontend/src/Questions.jsx
@@ -13,14 +13,14 @@ function truncate(str, max) {
   return `${str.slice(0, max - 3)}...`;
 }
 
-export default function Questions() {
+export default function Questions({ onBack = () => {} }) {
   const maxChars = Math.floor(window.innerWidth / 10);
   return (
-    <div style={{ position: 'relative' }}>
-      <button className="back-button" onClick={onBack}>
-        Back
-      </button>
-      <h1>Questions</h1>
+    <div>
+      <div className="view-header">
+        <h1>Questions</h1>
+        <button className="back-button" onClick={onBack}>Back</button>
+      </div>
       <ul>
         {sampleQuestions.map((q, i) => (
           <li key={i} className="question-item">

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -30,6 +30,7 @@ h1 {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
 
 .camera-window {
   margin-top: 1rem;
@@ -48,4 +49,15 @@ h1 {
   align-items: center;
   color: #fff;
 
+}
+
+.view-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 1rem;
+}
+
+.view-header h1 {
+  margin: 0;
 }


### PR DESCRIPTION
## Summary
- move welcome text into LoginForm and show only on the main page
- remove banner from App
- add consistent headers with Back button in each view
- style new headers in CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845bf0051e883278da785ce61a597ac