### PR TITLE
Add camera error handling

### DIFF
--- a/frontend/src/AddView.jsx
+++ b/frontend/src/AddView.jsx
@@ -3,6 +3,7 @@ import React, { useRef, useState, useEffect } from 'react';
 export default function AddView({ onBack = () => {} }) {
   const [stream, setStream] = useState(null);
   const [photo, setPhoto] = useState(null);
+  const [errorMessage, setErrorMessage] = useState('');
   const videoRef = useRef(null);
   const canvasRef = useRef(null);
 
@@ -15,14 +16,16 @@ export default function AddView({ onBack = () => {} }) {
   }, [stream]);
 
   async function handleEnableCamera() {
+    setErrorMessage('');
     if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+      setErrorMessage('Camera not supported');
       return;
     }
     try {
       const userStream = await navigator.mediaDevices.getUserMedia({ video: true });
       setStream(userStream);
     } catch (err) {
-      // Ignore errors for now
+      setErrorMessage('Failed to access camera');
     }
   }
 
@@ -48,6 +51,7 @@ export default function AddView({ onBack = () => {} }) {
         </button>
       </div>
       {!stream && <button onClick={handleEnableCamera}>Enable Camera</button>}
+      {errorMessage && <p className="error">{errorMessage}</p>}
       <div className="camera-window">
         {stream ? (
           <video

--- a/frontend/src/AddView.test.jsx
+++ b/frontend/src/AddView.test.jsx
@@ -4,6 +4,11 @@ import { vi } from 'vitest';
 import AddView from './AddView.jsx';
 
 describe('AddView', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete global.navigator.mediaDevices;
+  });
+
   it('shows Add title', () => {
     render(<AddView />);
     expect(screen.getByRole('heading', { name: 'Add' })).toBeInTheDocument();
@@ -25,5 +30,16 @@ describe('AddView', () => {
       expect(screen.getByRole('button', { name: /take photo/i })).toBeInTheDocument();
       expect(screen.getByTestId('camera-preview')).toBeInTheDocument();
     });
+  });
+
+  it('shows error when camera not supported', () => {
+    delete global.navigator.mediaDevices;
+
+    render(<AddView />);
+
+    const enableBtn = screen.getByRole('button', { name: /enable camera/i });
+    fireEvent.click(enableBtn);
+
+    expect(screen.getByText(/camera not supported/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- handle camera errors in AddView
- show error message when camera is not supported
- test camera support errors

## Testing
- `npm --prefix frontend test`

------
https://chatgpt.com/codex/tasks/task_e_6845c9319bd08327939ee4c468947e2e