### PR TITLE
Improve AddView debug and camera preview style

### DIFF
--- a/frontend/src/AddView.jsx
+++ b/frontend/src/AddView.jsx
@@ -4,13 +4,19 @@ export default function AddView({ onBack = () => {} }) {
   const [stream, setStream] = useState(null);
   const [photo, setPhoto] = useState(null);
   const [errorMessage, setErrorMessage] = useState('');
-  const [debugMessages, setDebugMessages] = useState([]);
+  // Start with a message so we know the debug box works
+  const [debugMessages, setDebugMessages] = useState(['Debug box ready']);
   const videoRef = useRef(null);
   const canvasRef = useRef(null);
 
   function addDebug(msg) {
     setDebugMessages((prev) => [...prev, msg]);
   }
+
+  // Confirm component is ready
+  useEffect(() => {
+    addDebug('AddView mounted');
+  }, []);
 
   useEffect(() => {
     if (videoRef.current && stream) {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -44,6 +44,7 @@ h1 {
   width: 320px;
   height: 240px;
   background: #000;
+  object-fit: cover;
 }
 
 .camera-placeholder {


### PR DESCRIPTION
## Summary
- show initial message in the debug box and log component mount
- ensure video preview fills its frame with `object-fit: cover`

## Testing
- `npm test --silent`
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6845e8d14ff48327bd70a7d10dc98b6f