### PR TITLE
Add camera switch & barcode scanning

### DIFF
--- a/frontend/src/AddView.test.jsx
+++ b/frontend/src/AddView.test.jsx
@@ -1,6 +1,20 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
+
+const startMock = vi.fn();
+const stopMock = vi.fn();
+
+vi.mock('./hooks/useBarcodeScanner.js', () => ({
+  default: () => ({
+    videoRef: { current: null },
+    barcode: '',
+    scanning: false,
+    start: startMock,
+    stop: stopMock,
+  }),
+}));
+
 import AddView from './AddView.jsx';
 
 describe('AddView', () => {
@@ -44,9 +58,11 @@ describe('AddView', () => {
     fireEvent.click(enableBtn);
 
     await waitFor(() => {
-      expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({ video: true });
+      expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({ video: { facingMode: 'user' } });
       expect(screen.getByRole('button', { name: /take photo/i })).toBeInTheDocument();
       expect(screen.getByTestId('camera-preview')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /switch to back/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /scan barcode/i })).toBeInTheDocument();
     });
 
     const debugOutput = screen.getByTestId('debug-output');
@@ -64,5 +80,60 @@ describe('AddView', () => {
     await waitFor(() => {
       expect(screen.getByText(/camera not supported/i)).toBeInTheDocument();
     });
+  });
+
+  it('switches between cameras', async () => {
+    const mockStream = {
+      active: true,
+      addEventListener: vi.fn(),
+      getVideoTracks: vi.fn(() => [
+        { readyState: 'live', addEventListener: vi.fn(), stop: vi.fn() },
+      ]),
+    };
+    global.navigator.mediaDevices = {
+      getUserMedia: vi.fn(() => Promise.resolve(mockStream)),
+    };
+
+    render(<AddView />);
+
+    fireEvent.click(screen.getByRole('button', { name: /enable camera/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /switch to back/i })).toBeInTheDocument();
+    });
+
+    navigator.mediaDevices.getUserMedia.mockResolvedValueOnce(mockStream);
+    const switchBtn = screen.getByRole('button', { name: /switch to back/i });
+    fireEvent.click(switchBtn);
+
+    await waitFor(() => {
+      expect(navigator.mediaDevices.getUserMedia).toHaveBeenLastCalledWith({
+        video: { facingMode: 'environment' },
+      });
+      expect(screen.getByRole('button', { name: /switch to front/i })).toBeInTheDocument();
+    });
+  });
+
+  it('starts barcode scanning', async () => {
+    global.navigator.mediaDevices = {
+      getUserMedia: vi.fn(() =>
+        Promise.resolve({
+          active: true,
+          addEventListener: vi.fn(),
+          getVideoTracks: vi.fn(() => [{ readyState: 'live', addEventListener: vi.fn() }]),
+        })
+      ),
+    };
+
+    render(<AddView />);
+
+    fireEvent.click(screen.getByRole('button', { name: /enable camera/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /scan barcode/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /scan barcode/i }));
+    expect(startMock).toHaveBeenCalled();
   });
 });

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -90,3 +90,9 @@ h1 {
   content: '\2190'; /* left arrow */
   font-size: 1rem;
 }
+
+.captured-photo {
+  width: 320px;
+  height: 240px;
+  object-fit: cover;
+}


### PR DESCRIPTION
## Summary
- switch between front and back cameras
- add barcode scanning button using custom hook
- resize captured photo to camera preview size
- update styles for captured images
- extend AddView tests for new functionality

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend test`

------
https://chatgpt.com/codex/tasks/task_e_6845f5826cec8327b6d34a084e7c5abc