### PR TITLE
Add Question audience support

### DIFF
--- a/server/src/main/java/com/memoritta/server/client/AnswerRepository.java
+++ b/server/src/main/java/com/memoritta/server/client/AnswerRepository.java
@@ -1,0 +1,13 @@
+package com.memoritta.server.client;
+
+import com.memoritta.server.dao.AnswerDao;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface AnswerRepository extends MongoRepository<AnswerDao, UUID> {
+    List<AnswerDao> findByQuestionId(UUID questionId);
+}

--- a/server/src/main/java/com/memoritta/server/client/QuestionRepository.java
+++ b/server/src/main/java/com/memoritta/server/client/QuestionRepository.java
@@ -1,0 +1,13 @@
+package com.memoritta.server.client;
+
+import com.memoritta.server.dao.QuestionDao;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface QuestionRepository extends MongoRepository<QuestionDao, UUID> {
+    List<QuestionDao> findByToUserId(UUID toUserId);
+}

--- a/server/src/main/java/com/memoritta/server/controller/AnswerController.java
+++ b/server/src/main/java/com/memoritta/server/controller/AnswerController.java
@@ -1,0 +1,41 @@
+package com.memoritta.server.controller;
+
+import com.memoritta.server.manager.AnswerManager;
+import com.memoritta.server.model.Answer;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/answer")
+public class AnswerController {
+
+    private final AnswerManager answerManager;
+
+    @PostMapping
+    @Operation(summary = "Add answer", description = "Adds an answer to a question")
+    public UUID addAnswer(
+            @RequestParam @Parameter(description = "Question ID") String questionId,
+            @RequestParam @Parameter(description = "User answering") String fromUserId,
+            @RequestParam @Parameter(description = "Answer text") String text
+    ) {
+        return answerManager.addAnswer(
+                UUID.fromString(questionId),
+                UUID.fromString(fromUserId),
+                text
+        );
+    }
+
+    @GetMapping
+    @Operation(summary = "List answers", description = "Lists answers for a question")
+    public List<Answer> listAnswers(
+            @RequestParam @Parameter(description = "Question ID") String questionId
+    ) {
+        return answerManager.listAnswers(UUID.fromString(questionId));
+    }
+}

--- a/server/src/main/java/com/memoritta/server/controller/QuestionController.java
+++ b/server/src/main/java/com/memoritta/server/controller/QuestionController.java
@@ -1,0 +1,41 @@
+package com.memoritta.server.controller;
+
+import com.memoritta.server.manager.QuestionManager;
+import com.memoritta.server.model.Question;
+import com.memoritta.server.model.QuestionAudience;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/question")
+public class QuestionController {
+
+    private final QuestionManager questionManager;
+
+    @PostMapping
+    @Operation(summary = "Ask a question", description = "Creates a new question")
+    public UUID askQuestion(
+            @RequestParam @Parameter(description = "ID of user asking") String fromUserId,
+            @RequestParam(required = false) @Parameter(description = "ID of user to ask") String toUserId,
+            @RequestParam @Parameter(description = "Question text") String question,
+            @RequestParam(defaultValue = "DIRECT") @Parameter(description = "Question audience: EVERYONE, FRIENDS, BEST_FRIENDS, DIRECT") String audience
+    ) {
+        UUID toId = toUserId == null ? null : UUID.fromString(toUserId);
+        QuestionAudience aud = QuestionAudience.valueOf(audience);
+        return questionManager.askQuestion(UUID.fromString(fromUserId), toId, question, aud);
+    }
+
+    @GetMapping
+    @Operation(summary = "List questions", description = "Lists questions for the given user")
+    public List<Question> listQuestions(
+            @RequestParam @Parameter(description = "ID of user to get questions for") String userId
+    ) {
+        return questionManager.listQuestionsForUser(UUID.fromString(userId));
+    }
+}

--- a/server/src/main/java/com/memoritta/server/dao/AnswerDao.java
+++ b/server/src/main/java/com/memoritta/server/dao/AnswerDao.java
@@ -1,0 +1,32 @@
+package com.memoritta.server.dao;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+@Document(collection = "answers")
+public class AnswerDao {
+    @Id
+    private UUID id;
+    private UUID questionId;
+    private UUID fromUserId;
+    private String text;
+
+    @CreatedDate
+    private Instant createdAt;
+    @LastModifiedDate
+    private Instant modifiedAt;
+    @CreatedBy
+    private UUID createdBy;
+}

--- a/server/src/main/java/com/memoritta/server/dao/QuestionDao.java
+++ b/server/src/main/java/com/memoritta/server/dao/QuestionDao.java
@@ -1,0 +1,36 @@
+package com.memoritta.server.dao;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import com.memoritta.server.model.QuestionAudience;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+@Document(collection = "questions")
+public class QuestionDao {
+    @Id
+    private UUID id;
+    private UUID fromUserId;
+    private UUID toUserId;
+    private String question;
+    private String answer;
+    private QuestionAudience audience;
+
+    @CreatedDate
+    private Instant createdAt;
+    @LastModifiedDate
+    private Instant modifiedAt;
+    @CreatedBy
+    private UUID createdBy;
+}

--- a/server/src/main/java/com/memoritta/server/manager/AnswerManager.java
+++ b/server/src/main/java/com/memoritta/server/manager/AnswerManager.java
@@ -1,0 +1,33 @@
+package com.memoritta.server.manager;
+
+import com.memoritta.server.client.AnswerRepository;
+import com.memoritta.server.mapper.AnswerMapper;
+import com.memoritta.server.model.Answer;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@AllArgsConstructor
+public class AnswerManager {
+
+    private final AnswerRepository answerRepository;
+
+    public UUID addAnswer(UUID questionId, UUID fromUserId, String text) {
+        Answer answer = Answer.builder()
+                .id(UUID.randomUUID())
+                .questionId(questionId)
+                .fromUserId(fromUserId)
+                .text(text)
+                .build();
+        return answerRepository.save(AnswerMapper.INSTANCE.toAnswerDao(answer)).getId();
+    }
+
+    public List<Answer> listAnswers(UUID questionId) {
+        return answerRepository.findByQuestionId(questionId).stream()
+                .map(AnswerMapper.INSTANCE::toAnswer)
+                .toList();
+    }
+}

--- a/server/src/main/java/com/memoritta/server/manager/QuestionManager.java
+++ b/server/src/main/java/com/memoritta/server/manager/QuestionManager.java
@@ -1,0 +1,37 @@
+package com.memoritta.server.manager;
+
+import com.memoritta.server.client.QuestionRepository;
+import com.memoritta.server.mapper.QuestionMapper;
+import com.memoritta.server.model.Question;
+import com.memoritta.server.model.QuestionAudience;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@AllArgsConstructor
+public class QuestionManager {
+
+    private final QuestionRepository questionRepository;
+
+    public UUID askQuestion(UUID fromUserId, UUID toUserId, String questionText, QuestionAudience audience) {
+        Question question = Question.builder()
+                .id(UUID.randomUUID())
+                .fromUserId(fromUserId)
+                .toUserId(toUserId)
+                .question(questionText)
+                .audience(audience)
+                .build();
+        Question saved = QuestionMapper.INSTANCE.toQuestion(questionRepository.save(QuestionMapper.INSTANCE.toQuestionDao(question)));
+        return saved.getId();
+    }
+
+    public List<Question> listQuestionsForUser(UUID userId) {
+        return questionRepository.findAll().stream()
+                .filter(dao -> dao.getAudience() != QuestionAudience.DIRECT || userId.equals(dao.getToUserId()))
+                .map(QuestionMapper.INSTANCE::toQuestion)
+                .toList();
+    }
+}

--- a/server/src/main/java/com/memoritta/server/mapper/AnswerMapper.java
+++ b/server/src/main/java/com/memoritta/server/mapper/AnswerMapper.java
@@ -1,0 +1,13 @@
+package com.memoritta.server.mapper;
+
+import com.memoritta.server.dao.AnswerDao;
+import com.memoritta.server.model.Answer;
+import org.mapstruct.factory.Mappers;
+
+@org.mapstruct.Mapper
+public interface AnswerMapper {
+    AnswerMapper INSTANCE = Mappers.getMapper(AnswerMapper.class);
+
+    AnswerDao toAnswerDao(Answer answer);
+    Answer toAnswer(AnswerDao dao);
+}

--- a/server/src/main/java/com/memoritta/server/mapper/QuestionMapper.java
+++ b/server/src/main/java/com/memoritta/server/mapper/QuestionMapper.java
@@ -1,0 +1,13 @@
+package com.memoritta.server.mapper;
+
+import com.memoritta.server.dao.QuestionDao;
+import com.memoritta.server.model.Question;
+import org.mapstruct.factory.Mappers;
+
+@org.mapstruct.Mapper
+public interface QuestionMapper {
+    QuestionMapper INSTANCE = Mappers.getMapper(QuestionMapper.class);
+
+    QuestionDao toQuestionDao(Question question);
+    Question toQuestion(QuestionDao dao);
+}

--- a/server/src/main/java/com/memoritta/server/model/Answer.java
+++ b/server/src/main/java/com/memoritta/server/model/Answer.java
@@ -1,0 +1,17 @@
+package com.memoritta.server.model;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+public class Answer {
+    private UUID id;
+    private UUID questionId;
+    private UUID fromUserId;
+    private String text;
+}

--- a/server/src/main/java/com/memoritta/server/model/Question.java
+++ b/server/src/main/java/com/memoritta/server/model/Question.java
@@ -1,0 +1,19 @@
+package com.memoritta.server.model;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+public class Question {
+    private UUID id;
+    private UUID fromUserId;
+    private UUID toUserId;
+    private String question;
+    private String answer;
+    private QuestionAudience audience;
+}

--- a/server/src/main/java/com/memoritta/server/model/QuestionAudience.java
+++ b/server/src/main/java/com/memoritta/server/model/QuestionAudience.java
@@ -1,0 +1,8 @@
+package com.memoritta.server.model;
+
+public enum QuestionAudience {
+    EVERYONE,
+    FRIENDS,
+    BEST_FRIENDS,
+    DIRECT
+}

--- a/server/src/test/java/com/memoritta/server/controller/AnswerControllerTest.java
+++ b/server/src/test/java/com/memoritta/server/controller/AnswerControllerTest.java
@@ -1,0 +1,65 @@
+package com.memoritta.server.controller;
+
+import com.memoritta.server.client.AnswerRepository;
+import com.memoritta.server.dao.AnswerDao;
+import com.memoritta.server.manager.AnswerManager;
+import com.memoritta.server.model.Answer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@ContextConfiguration(classes = {AnswerControllerTest.Config.class, AnswerManager.class, AnswerController.class})
+class AnswerControllerTest {
+
+    @Configuration
+    static class Config {
+        @Bean
+        AnswerRepository answerRepository() {
+            return mock(AnswerRepository.class);
+        }
+    }
+
+    @Autowired
+    private AnswerRepository answerRepository;
+    @Autowired
+    private AnswerController answerController;
+
+    @BeforeEach
+    void resetRepo() {
+        reset(answerRepository);
+    }
+
+    @Test
+    void addAnswer_shouldReturnId() {
+        UUID id = UUID.randomUUID();
+        when(answerRepository.save(any(AnswerDao.class)))
+                .thenReturn(AnswerDao.builder().id(id).build());
+
+        UUID result = answerController.addAnswer(id.toString(), id.toString(), "txt");
+
+        assertThat(result).isEqualTo(id);
+    }
+
+    @Test
+    void listAnswers_shouldReturnData() {
+        UUID qid = UUID.randomUUID();
+        when(answerRepository.findByQuestionId(qid))
+                .thenReturn(List.of(AnswerDao.builder().id(UUID.randomUUID()).questionId(qid).build()));
+
+        List<Answer> result = answerController.listAnswers(qid.toString());
+
+        assertThat(result).hasSize(1);
+    }
+}

--- a/server/src/test/java/com/memoritta/server/controller/QuestionControllerTest.java
+++ b/server/src/test/java/com/memoritta/server/controller/QuestionControllerTest.java
@@ -1,0 +1,75 @@
+package com.memoritta.server.controller;
+
+import com.memoritta.server.client.QuestionRepository;
+import com.memoritta.server.dao.QuestionDao;
+import com.memoritta.server.manager.QuestionManager;
+import com.memoritta.server.model.Question;
+import com.memoritta.server.model.QuestionAudience;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@ContextConfiguration(classes = {QuestionControllerTest.Config.class, QuestionManager.class, QuestionController.class})
+class QuestionControllerTest {
+
+    @Configuration
+    static class Config {
+        @Bean
+        QuestionRepository questionRepository() {
+            return mock(QuestionRepository.class);
+        }
+    }
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @Autowired
+    private QuestionController questionController;
+
+    @BeforeEach
+    void resetRepo() {
+        reset(questionRepository);
+    }
+
+    @Test
+    void askQuestion_shouldReturnUuid() {
+        UUID id = UUID.randomUUID();
+        when(questionRepository.save(any(QuestionDao.class)))
+                .thenReturn(QuestionDao.builder().id(id).build());
+
+        UUID result = questionController.askQuestion(id.toString(), null, "hi?", "DIRECT");
+
+        assertThat(result).isEqualTo(id);
+    }
+
+    @Test
+    void listQuestions_shouldReturnFiltered() {
+        UUID userId = UUID.randomUUID();
+        QuestionDao direct = QuestionDao.builder()
+                .id(UUID.randomUUID())
+                .toUserId(userId)
+                .audience(QuestionAudience.DIRECT)
+                .build();
+        QuestionDao publicQ = QuestionDao.builder()
+                .id(UUID.randomUUID())
+                .audience(QuestionAudience.EVERYONE)
+                .build();
+        when(questionRepository.findAll()).thenReturn(List.of(direct, publicQ));
+
+        List<Question> result = questionController.listQuestions(userId.toString());
+
+        assertThat(result).hasSize(2);
+    }
+}

--- a/server/src/test/java/com/memoritta/server/manager/AnswerManagerTest.java
+++ b/server/src/test/java/com/memoritta/server/manager/AnswerManagerTest.java
@@ -1,0 +1,70 @@
+package com.memoritta.server.manager;
+
+import com.memoritta.server.client.AnswerRepository;
+import com.memoritta.server.dao.AnswerDao;
+import com.memoritta.server.model.Answer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@ContextConfiguration(classes = {AnswerManagerTest.Config.class, AnswerManager.class})
+class AnswerManagerTest {
+
+    @Configuration
+    static class Config {
+        @Bean
+        AnswerRepository answerRepository() {
+            return mock(AnswerRepository.class);
+        }
+    }
+
+    @Autowired
+    private AnswerRepository answerRepository;
+    @Autowired
+    private AnswerManager answerManager;
+
+    @BeforeEach
+    void resetRepo() {
+        reset(answerRepository);
+    }
+
+    @Test
+    void addAnswer_shouldReturnId() {
+        UUID id = UUID.randomUUID();
+        when(answerRepository.save(any(AnswerDao.class)))
+                .thenReturn(AnswerDao.builder().id(id).build());
+
+        UUID result = answerManager.addAnswer(id, id, "text");
+
+        assertThat(result).isEqualTo(id);
+        verify(answerRepository).save(any(AnswerDao.class));
+    }
+
+    @Test
+    void listAnswers_shouldReturnMapped() {
+        UUID qid = UUID.randomUUID();
+        AnswerDao dao = AnswerDao.builder()
+                .id(UUID.randomUUID())
+                .questionId(qid)
+                .fromUserId(UUID.randomUUID())
+                .text("a")
+                .build();
+        when(answerRepository.findByQuestionId(qid)).thenReturn(List.of(dao));
+
+        List<Answer> result = answerManager.listAnswers(qid);
+
+        assertThat(result).hasSize(1);
+    }
+}

--- a/server/src/test/java/com/memoritta/server/manager/QuestionManagerTest.java
+++ b/server/src/test/java/com/memoritta/server/manager/QuestionManagerTest.java
@@ -1,0 +1,81 @@
+package com.memoritta.server.manager;
+
+import com.memoritta.server.client.QuestionRepository;
+import com.memoritta.server.dao.QuestionDao;
+import com.memoritta.server.model.Question;
+import com.memoritta.server.model.QuestionAudience;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@ContextConfiguration(classes = {QuestionManagerTest.Config.class, QuestionManager.class})
+class QuestionManagerTest {
+
+    @Configuration
+    static class Config {
+        @Bean
+        QuestionRepository questionRepository() {
+            return mock(QuestionRepository.class);
+        }
+    }
+
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @Autowired
+    private QuestionManager questionManager;
+
+    @BeforeEach
+    void resetRepo() {
+        reset(questionRepository);
+    }
+
+    @Test
+    void askQuestion_shouldSaveAndReturnId() {
+        UUID id = UUID.randomUUID();
+        when(questionRepository.save(any(QuestionDao.class)))
+                .thenReturn(QuestionDao.builder().id(id).build());
+
+        UUID result = questionManager.askQuestion(id, null, "test?", QuestionAudience.DIRECT);
+
+        assertThat(result).isEqualTo(id);
+        verify(questionRepository).save(any(QuestionDao.class));
+    }
+
+    @Test
+    void listQuestionsForUser_shouldFilterDirectAudience() {
+        UUID userId = UUID.randomUUID();
+        QuestionDao q1 = QuestionDao.builder()
+                .id(UUID.randomUUID())
+                .toUserId(UUID.randomUUID())
+                .audience(QuestionAudience.DIRECT)
+                .build();
+        QuestionDao q2 = QuestionDao.builder()
+                .id(UUID.randomUUID())
+                .toUserId(userId)
+                .audience(QuestionAudience.DIRECT)
+                .build();
+        QuestionDao q3 = QuestionDao.builder()
+                .id(UUID.randomUUID())
+                .audience(QuestionAudience.EVERYONE)
+                .build();
+        when(questionRepository.findAll()).thenReturn(List.of(q1, q2, q3));
+
+        List<Question> result = questionManager.listQuestionsForUser(userId);
+
+        assertThat(result).extracting(Question::getId)
+                .containsExactlyInAnyOrder(q2.getId(), q3.getId());
+    }
+}

--- a/server/src/test/java/integration/AnswerControllerIT.java
+++ b/server/src/test/java/integration/AnswerControllerIT.java
@@ -1,0 +1,42 @@
+package integration;
+
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.junit.jupiter.EnabledIf;
+
+import java.util.UUID;
+
+import static integration.IntegrationTestUtil.assumeServerRunning;
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@Tag("integration")
+public class AnswerControllerIT {
+
+    @EnabledIf(expression = "#{systemEnvironment['PROD'] == null}", reason = "Disabled in PROD environment")
+    @Test
+    void testAddAnswer() {
+        assumeServerRunning();
+        RestAssured.baseURI = "http://127.0.0.1:9090";
+
+        Response response = given()
+                .auth().basic("admin", "admin")
+                .contentType("application/x-www-form-urlencoded")
+                .param("questionId", UUID.randomUUID().toString())
+                .param("fromUserId", UUID.randomUUID().toString())
+                .param("text", "Integration answer")
+                .when()
+                .post("/answer")
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        UUID id = response.as(UUID.class);
+        assertThat(id).isNotNull();
+    }
+}

--- a/server/src/test/java/integration/QuestionControllerIT.java
+++ b/server/src/test/java/integration/QuestionControllerIT.java
@@ -1,0 +1,42 @@
+package integration;
+
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.junit.jupiter.EnabledIf;
+
+import java.util.UUID;
+
+import static integration.IntegrationTestUtil.assumeServerRunning;
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@Tag("integration")
+public class QuestionControllerIT {
+
+    @EnabledIf(expression = "#{systemEnvironment['PROD'] == null}", reason = "Disabled in PROD environment")
+    @Test
+    void testAskQuestion() {
+        assumeServerRunning();
+        RestAssured.baseURI = "http://127.0.0.1:9090";
+
+        Response response = given()
+                .auth().basic("admin", "admin")
+                .contentType("application/x-www-form-urlencoded")
+                .param("fromUserId", UUID.randomUUID().toString())
+                .param("question", "Integration test question")
+                .param("audience", "EVERYONE")
+                .when()
+                .post("/question")
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        UUID id = response.as(UUID.class);
+        assertThat(id).isNotNull();
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `QuestionAudience` enum to mark who should see a question
- extend `Question` and `QuestionDao` with the new field
- update `QuestionManager` and `QuestionController` to handle audience

## Testing
- `mvn -q test -pl server` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68468ee799a48327a2e17de9443e544b