### PR TITLE
Add Redux

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,9 +8,11 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@reduxjs/toolkit": "^2.8.2",
         "@zxing/browser": "^0.1.5",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-redux": "^9.2.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.0",
@@ -938,6 +940,32 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.8.2.tgz",
+      "integrity": "sha512-MYlOhQ0sLdw4ud48FoC5w0dH9VfWQjtCjreKwYTT3l+r427qYC5Y8PihNutepr8XrNaBUDQo9khWUwQxZaqt5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.9",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.9.tgz",
@@ -1225,6 +1253,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@testing-library/dom": {
       "version": "9.3.4",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
@@ -1399,7 +1439,7 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true
     },
@@ -1407,7 +1447,7 @@
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1424,6 +1464,12 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.5.1",
@@ -1891,7 +1937,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true
     },
@@ -2455,6 +2501,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/indent-string": {
@@ -3145,6 +3201,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3169,6 +3248,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -3189,6 +3283,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.41.1",
@@ -3628,6 +3728,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,9 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "@zxing/browser": "^0.1.5"
+    "@zxing/browser": "^0.1.5",
+    "@reduxjs/toolkit": "^2.8.2",
+    "react-redux": "^9.2.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,10 +1,14 @@
 import React from 'react';
+import { Provider } from 'react-redux';
 import LoginForm from './LoginForm.jsx';
+import store from './store.js';
 
 export default function App() {
   return (
-    <div>
-      <LoginForm />
-    </div>
+    <Provider store={store}>
+      <div>
+        <LoginForm />
+      </div>
+    </Provider>
   );
 }

--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { setUserInfo, setCurrentView } from './store.js';
 
 import AddView from './AddView.jsx';
 import Compare from './Compare.jsx';
@@ -13,8 +15,9 @@ export default function LoginForm({ onLogin }) {
   const [password, setPassword] = useState('');
   const [remember, setRemember] = useState(false);
   const [message, setMessage] = useState('');
-  const [userInfo, setUserInfo] = useState(null);
-  const [currentView, setCurrentView] = useState(null);
+  const userInfo = useSelector((state) => state.user.userInfo);
+  const currentView = useSelector((state) => state.user.currentView);
+  const dispatch = useDispatch();
 
   useEffect(() => {
     const matchEmail = document.cookie.match(/(?:^|;)\s*email=([^;]+)/);
@@ -31,7 +34,7 @@ export default function LoginForm({ onLogin }) {
   async function handleSubmit(e) {
     e.preventDefault();
     setMessage('');
-    setUserInfo(null);
+    dispatch(setUserInfo(null));
     try {
       const response = await fetch(`${BACKEND_URL}/user`, {
         method: 'POST',
@@ -42,7 +45,7 @@ export default function LoginForm({ onLogin }) {
         throw new Error('login failed');
       }
       const data = await response.json();
-      setUserInfo(data.user);
+      dispatch(setUserInfo(data.user));
       if (remember) {
         document.cookie = `email=${encodeURIComponent(email)}; path=/`;
         document.cookie = `password=${encodeURIComponent(password)}; path=/`;
@@ -107,36 +110,36 @@ export default function LoginForm({ onLogin }) {
                 <li>ID: {userInfo.id}</li>
               </ul>
               <div>
-                <button onClick={() => setCurrentView('add')}>Add</button>
+                <button onClick={() => dispatch(setCurrentView('add'))}>Add</button>
               </div>
               <div>
-                <button onClick={() => setCurrentView('compare')}>Compare</button>
+                <button onClick={() => dispatch(setCurrentView('compare'))}>Compare</button>
               </div>
               <div>
-                <button onClick={() => setCurrentView('ask')}>Ask</button>
+                <button onClick={() => dispatch(setCurrentView('ask'))}>Ask</button>
               </div>
               <div>
-                <button onClick={() => setCurrentView('questions')}>Questions</button>
+                <button onClick={() => dispatch(setCurrentView('questions'))}>Questions</button>
               </div>
               <div>
-                <button onClick={() => setCurrentView('friends')}>Friends</button>
+                <button onClick={() => dispatch(setCurrentView('friends'))}>Friends</button>
               </div>
             </>
           )}
           {currentView === 'add' && (
-            <AddView onBack={() => setCurrentView(null)} />
+            <AddView onBack={() => dispatch(setCurrentView(null))} />
           )}
           {currentView === 'compare' && (
-            <Compare onBack={() => setCurrentView(null)} />
+            <Compare onBack={() => dispatch(setCurrentView(null))} />
           )}
           {currentView === 'ask' && (
-            <Ask onBack={() => setCurrentView(null)} />
+            <Ask onBack={() => dispatch(setCurrentView(null))} />
           )}
           {currentView === 'questions' && (
-            <Questions onBack={() => setCurrentView(null)} />
+            <Questions onBack={() => dispatch(setCurrentView(null))} />
           )}
           {currentView === 'friends' && (
-            <Friends onBack={() => setCurrentView(null)} />
+            <Friends onBack={() => dispatch(setCurrentView(null))} />
           )}
         </div>
       )}

--- a/frontend/src/LoginForm.test.jsx
+++ b/frontend/src/LoginForm.test.jsx
@@ -3,11 +3,18 @@ import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import LoginForm from './LoginForm.jsx';
 import { BACKEND_URL } from './config.js';
+import { Provider } from 'react-redux';
+import { createAppStore } from './store.js';
+
+function renderWithProvider(ui) {
+  const testStore = createAppStore();
+  return render(<Provider store={testStore}>{ui}</Provider>);
+}
 
 describe('LoginForm', () => {
   afterEach(() => vi.restoreAllMocks());
   it('renders email and password inputs', () => {
-    render(<LoginForm />);
+    renderWithProvider(<LoginForm />);
     expect(screen.getByTestId('email-input')).toBeInTheDocument();
     expect(screen.getByTestId('password-input')).toBeInTheDocument();
     expect(screen.getByTestId('remember-checkbox')).toBeInTheDocument();
@@ -25,7 +32,7 @@ describe('LoginForm', () => {
       })
     );
 
-    render(<LoginForm />);
+    renderWithProvider(<LoginForm />);
 
     fireEvent.change(screen.getByTestId('email-input'), {
       target: { value: 'user@example.com' },
@@ -68,7 +75,7 @@ describe('LoginForm', () => {
       })
     );
 
-    render(<LoginForm />);
+    renderWithProvider(<LoginForm />);
     fireEvent.change(screen.getByTestId('email-input'), {
       target: { value: 'user@example.com' },
     });
@@ -87,7 +94,7 @@ describe('LoginForm', () => {
   it('prefills inputs from cookies on load', () => {
     document.cookie = 'email=foo%40example.com';
     document.cookie = 'password=bar';
-    render(<LoginForm />);
+    renderWithProvider(<LoginForm />);
     expect(screen.getByTestId('email-input')).toHaveValue('foo@example.com');
     expect(screen.getByTestId('password-input')).toHaveValue('bar');
   });
@@ -108,7 +115,7 @@ describe('LoginForm', () => {
         })
       );
 
-      render(<LoginForm />);
+      renderWithProvider(<LoginForm />);
       fireEvent.change(screen.getByTestId('email-input'), {
         target: { value: 'user@example.com' },
       });

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -1,0 +1,29 @@
+import { configureStore, createSlice } from '@reduxjs/toolkit';
+
+const userSlice = createSlice({
+  name: 'user',
+  initialState: { userInfo: null, currentView: null },
+  reducers: {
+    setUserInfo: (state, action) => {
+      state.userInfo = action.payload;
+    },
+    setCurrentView: (state, action) => {
+      state.currentView = action.payload;
+    },
+  },
+});
+
+export const { setUserInfo, setCurrentView } = userSlice.actions;
+
+export function createAppStore(preloadedState) {
+  return configureStore({
+    reducer: {
+      user: userSlice.reducer,
+    },
+    preloadedState,
+  });
+}
+
+const store = createAppStore();
+
+export default store;


### PR DESCRIPTION
## Summary
- add Redux Toolkit and React-Redux
- manage login view and user info via Redux store
- provide store with Provider in App
- update tests for Redux store

## Testing
- `npm test --silent --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68468e00d33c8327b597602cda27a2ef