### PR TITLE
Add friend relation storage

### DIFF
--- a/server/src/main/java/com/memoritta/server/client/FriendRelationRepository.java
+++ b/server/src/main/java/com/memoritta/server/client/FriendRelationRepository.java
@@ -1,0 +1,13 @@
+package com.memoritta.server.client;
+
+import com.memoritta.server.dao.FriendRelationDao;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface FriendRelationRepository extends MongoRepository<FriendRelationDao, UUID> {
+    List<FriendRelationDao> findByUserId(UUID userId);
+}

--- a/server/src/main/java/com/memoritta/server/controller/FriendRelationController.java
+++ b/server/src/main/java/com/memoritta/server/controller/FriendRelationController.java
@@ -1,0 +1,42 @@
+package com.memoritta.server.controller;
+
+import com.memoritta.server.manager.FriendRelationManager;
+import com.memoritta.server.model.FriendRelation;
+import com.memoritta.server.model.FriendshipType;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/friend")
+public class FriendRelationController {
+
+    private final FriendRelationManager manager;
+
+    @PostMapping
+    @Operation(summary = "Add friend relation", description = "Adds a friend or best friend relation")
+    public UUID addFriend(
+            @RequestParam @Parameter(description = "User ID owning relation") String userId,
+            @RequestParam @Parameter(description = "Friend ID") String friendId,
+            @RequestParam(defaultValue = "FRIENDS") @Parameter(description = "Relation type: FRIENDS or BEST_FRIENDS") String type
+    ) {
+        return manager.addFriend(
+                UUID.fromString(userId),
+                UUID.fromString(friendId),
+                FriendshipType.valueOf(type)
+        );
+    }
+
+    @GetMapping
+    @Operation(summary = "List friends", description = "Lists relations for user")
+    public List<FriendRelation> listFriends(
+            @RequestParam @Parameter(description = "User ID to list relations for") String userId
+    ) {
+        return manager.listFriends(UUID.fromString(userId));
+    }
+}

--- a/server/src/main/java/com/memoritta/server/dao/FriendRelationDao.java
+++ b/server/src/main/java/com/memoritta/server/dao/FriendRelationDao.java
@@ -1,0 +1,33 @@
+package com.memoritta.server.dao;
+
+import com.memoritta.server.model.FriendshipType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+@Document(collection = "friends")
+public class FriendRelationDao {
+    @Id
+    private UUID id;
+    private UUID userId;
+    private UUID friendId;
+    private FriendshipType type;
+
+    @CreatedDate
+    private Instant createdAt;
+    @LastModifiedDate
+    private Instant modifiedAt;
+    @CreatedBy
+    private UUID createdBy;
+}

--- a/server/src/main/java/com/memoritta/server/manager/FriendRelationManager.java
+++ b/server/src/main/java/com/memoritta/server/manager/FriendRelationManager.java
@@ -1,0 +1,34 @@
+package com.memoritta.server.manager;
+
+import com.memoritta.server.client.FriendRelationRepository;
+import com.memoritta.server.mapper.FriendRelationMapper;
+import com.memoritta.server.model.FriendRelation;
+import com.memoritta.server.model.FriendshipType;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@AllArgsConstructor
+public class FriendRelationManager {
+
+    private final FriendRelationRepository repository;
+
+    public UUID addFriend(UUID userId, UUID friendId, FriendshipType type) {
+        FriendRelation relation = FriendRelation.builder()
+                .id(UUID.randomUUID())
+                .userId(userId)
+                .friendId(friendId)
+                .type(type)
+                .build();
+        return repository.save(FriendRelationMapper.INSTANCE.toFriendRelationDao(relation)).getId();
+    }
+
+    public List<FriendRelation> listFriends(UUID userId) {
+        return repository.findByUserId(userId).stream()
+                .map(FriendRelationMapper.INSTANCE::toFriendRelation)
+                .toList();
+    }
+}

--- a/server/src/main/java/com/memoritta/server/mapper/FriendRelationMapper.java
+++ b/server/src/main/java/com/memoritta/server/mapper/FriendRelationMapper.java
@@ -1,0 +1,13 @@
+package com.memoritta.server.mapper;
+
+import com.memoritta.server.dao.FriendRelationDao;
+import com.memoritta.server.model.FriendRelation;
+import org.mapstruct.factory.Mappers;
+
+@org.mapstruct.Mapper
+public interface FriendRelationMapper {
+    FriendRelationMapper INSTANCE = Mappers.getMapper(FriendRelationMapper.class);
+
+    FriendRelationDao toFriendRelationDao(FriendRelation relation);
+    FriendRelation toFriendRelation(FriendRelationDao dao);
+}

--- a/server/src/main/java/com/memoritta/server/model/FriendRelation.java
+++ b/server/src/main/java/com/memoritta/server/model/FriendRelation.java
@@ -1,0 +1,17 @@
+package com.memoritta.server.model;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+public class FriendRelation {
+    private UUID id;
+    private UUID userId;
+    private UUID friendId;
+    private FriendshipType type;
+}

--- a/server/src/main/java/com/memoritta/server/model/FriendshipType.java
+++ b/server/src/main/java/com/memoritta/server/model/FriendshipType.java
@@ -1,0 +1,6 @@
+package com.memoritta.server.model;
+
+public enum FriendshipType {
+    FRIENDS,
+    BEST_FRIENDS
+}

--- a/server/src/test/java/com/memoritta/server/controller/FriendRelationControllerTest.java
+++ b/server/src/test/java/com/memoritta/server/controller/FriendRelationControllerTest.java
@@ -1,0 +1,67 @@
+package com.memoritta.server.controller;
+
+import com.memoritta.server.client.FriendRelationRepository;
+import com.memoritta.server.dao.FriendRelationDao;
+import com.memoritta.server.manager.FriendRelationManager;
+import com.memoritta.server.model.FriendRelation;
+import com.memoritta.server.model.FriendshipType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@ContextConfiguration(classes = {FriendRelationControllerTest.Config.class, FriendRelationManager.class, FriendRelationController.class})
+class FriendRelationControllerTest {
+
+    @Configuration
+    static class Config {
+        @Bean
+        FriendRelationRepository friendRelationRepository() {
+            return mock(FriendRelationRepository.class);
+        }
+    }
+
+    @Autowired
+    private FriendRelationRepository repository;
+
+    @Autowired
+    private FriendRelationController controller;
+
+    @BeforeEach
+    void resetRepo() {
+        reset(repository);
+    }
+
+    @Test
+    void addFriend_shouldReturnId() {
+        UUID id = UUID.randomUUID();
+        when(repository.save(any(FriendRelationDao.class)))
+                .thenReturn(FriendRelationDao.builder().id(id).build());
+
+        UUID result = controller.addFriend(id.toString(), id.toString(), "FRIENDS");
+
+        assertThat(result).isEqualTo(id);
+    }
+
+    @Test
+    void listFriends_shouldReturnData() {
+        UUID userId = UUID.randomUUID();
+        when(repository.findByUserId(userId))
+                .thenReturn(List.of(FriendRelationDao.builder().id(UUID.randomUUID()).userId(userId).type(FriendshipType.FRIENDS).build()));
+
+        List<FriendRelation> result = controller.listFriends(userId.toString());
+
+        assertThat(result).hasSize(1);
+    }
+}


### PR DESCRIPTION
## Summary
- add `FriendshipType` enum
- add model, DAO, mapper and repository for friend relations
- implement manager and controller for the new feature
- add unit tests for the controller

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6846d11162c88327a6dfdb88ac5d81b4