### PR TITLE
Fix MapStruct builder usage

### DIFF
--- a/server/src/main/java/com/memoritta/server/dao/AnswerDao.java
+++ b/server/src/main/java/com/memoritta/server/dao/AnswerDao.java
@@ -2,6 +2,7 @@ package com.memoritta.server.dao;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
@@ -16,6 +17,7 @@ import java.util.UUID;
 @Setter
 @Builder
 @Document(collection = "answers")
+@NoArgsConstructor
 public class AnswerDao {
     @Id
     private UUID id;

--- a/server/src/main/java/com/memoritta/server/dao/DescriptionDao.java
+++ b/server/src/main/java/com/memoritta/server/dao/DescriptionDao.java
@@ -2,6 +2,7 @@ package com.memoritta.server.dao;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.Indexed;
@@ -14,6 +15,7 @@ import java.util.UUID;
 @Setter
 @Builder
 @Document(collection = "descriptions")
+@NoArgsConstructor
 public class DescriptionDao {
     @Id
     private UUID id;

--- a/server/src/main/java/com/memoritta/server/dao/FriendRelationDao.java
+++ b/server/src/main/java/com/memoritta/server/dao/FriendRelationDao.java
@@ -3,6 +3,7 @@ package com.memoritta.server.dao;
 import com.memoritta.server.model.FriendshipType;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
@@ -17,6 +18,7 @@ import java.util.UUID;
 @Setter
 @Builder
 @Document(collection = "friends")
+@NoArgsConstructor
 public class FriendRelationDao {
     @Id
     private UUID id;

--- a/server/src/main/java/com/memoritta/server/dao/ItemDao.java
+++ b/server/src/main/java/com/memoritta/server/dao/ItemDao.java
@@ -2,6 +2,7 @@ package com.memoritta.server.dao;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
@@ -17,6 +18,7 @@ import java.util.UUID;
 @Setter
 @Builder
 @Document(collection = "items")
+@NoArgsConstructor
 public class ItemDao {
     @Id
     private UUID id;

--- a/server/src/main/java/com/memoritta/server/dao/PictureOfItemDao.java
+++ b/server/src/main/java/com/memoritta/server/dao/PictureOfItemDao.java
@@ -2,6 +2,7 @@ package com.memoritta.server.dao;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -13,6 +14,7 @@ import java.util.UUID;
 @Setter
 @Builder
 @Document(collection = "pictures")
+@NoArgsConstructor
 public class PictureOfItemDao {
     @Id
     private UUID id;

--- a/server/src/main/java/com/memoritta/server/dao/QuestionDao.java
+++ b/server/src/main/java/com/memoritta/server/dao/QuestionDao.java
@@ -2,6 +2,7 @@ package com.memoritta.server.dao;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
@@ -18,6 +19,7 @@ import java.util.UUID;
 @Setter
 @Builder
 @Document(collection = "questions")
+@NoArgsConstructor
 public class QuestionDao {
     @Id
     private UUID id;

--- a/server/src/main/java/com/memoritta/server/dao/UserDao.java
+++ b/server/src/main/java/com/memoritta/server/dao/UserDao.java
@@ -2,6 +2,7 @@ package com.memoritta.server.dao;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
@@ -18,6 +19,7 @@ import java.util.UUID;
 @Getter
 @Builder
 @Document(collection = "users")
+@NoArgsConstructor
 public class UserDao {
     @Id
     private UUID id;

--- a/server/src/main/java/com/memoritta/server/mapper/AnswerMapper.java
+++ b/server/src/main/java/com/memoritta/server/mapper/AnswerMapper.java
@@ -4,7 +4,10 @@ import com.memoritta.server.dao.AnswerDao;
 import com.memoritta.server.model.Answer;
 import org.mapstruct.factory.Mappers;
 
-@org.mapstruct.Mapper
+@org.mapstruct.Mapper(
+    unmappedTargetPolicy = org.mapstruct.ReportingPolicy.IGNORE,
+    builder = @org.mapstruct.Builder(disableBuilder = true)
+)
 public interface AnswerMapper {
     AnswerMapper INSTANCE = Mappers.getMapper(AnswerMapper.class);
 

--- a/server/src/main/java/com/memoritta/server/mapper/ItemMapper.java
+++ b/server/src/main/java/com/memoritta/server/mapper/ItemMapper.java
@@ -4,7 +4,10 @@ import com.memoritta.server.model.Item;
 import com.memoritta.server.dao.ItemDao;
 import org.mapstruct.factory.Mappers;
 
-@org.mapstruct.Mapper
+@org.mapstruct.Mapper(
+    unmappedTargetPolicy = org.mapstruct.ReportingPolicy.IGNORE,
+    builder = @org.mapstruct.Builder(disableBuilder = true)
+)
 public interface ItemMapper {
     ItemMapper INSTANCE = Mappers.getMapper(ItemMapper.class);
 

--- a/server/src/main/java/com/memoritta/server/mapper/QuestionMapper.java
+++ b/server/src/main/java/com/memoritta/server/mapper/QuestionMapper.java
@@ -4,7 +4,10 @@ import com.memoritta.server.dao.QuestionDao;
 import com.memoritta.server.model.Question;
 import org.mapstruct.factory.Mappers;
 
-@org.mapstruct.Mapper
+@org.mapstruct.Mapper(
+    unmappedTargetPolicy = org.mapstruct.ReportingPolicy.IGNORE,
+    builder = @org.mapstruct.Builder(disableBuilder = true)
+)
 public interface QuestionMapper {
     QuestionMapper INSTANCE = Mappers.getMapper(QuestionMapper.class);
 

--- a/server/src/main/java/com/memoritta/server/model/Answer.java
+++ b/server/src/main/java/com/memoritta/server/model/Answer.java
@@ -2,6 +2,7 @@ package com.memoritta.server.model;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.UUID;
@@ -9,6 +10,7 @@ import java.util.UUID;
 @Getter
 @Setter
 @Builder
+@NoArgsConstructor
 public class Answer {
     private UUID id;
     private UUID questionId;

--- a/server/src/main/java/com/memoritta/server/model/AuthenticatedUser.java
+++ b/server/src/main/java/com/memoritta/server/model/AuthenticatedUser.java
@@ -2,11 +2,13 @@ package com.memoritta.server.model;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
 @Builder
+@NoArgsConstructor
 public class AuthenticatedUser {
     private String jwtToken;
     private User user;

--- a/server/src/main/java/com/memoritta/server/model/Credentials.java
+++ b/server/src/main/java/com/memoritta/server/model/Credentials.java
@@ -2,11 +2,13 @@ package com.memoritta.server.model;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Setter
 @Getter
 @Builder
+@NoArgsConstructor
 public class Credentials {
     private String email;
     private String password;

--- a/server/src/main/java/com/memoritta/server/model/Description.java
+++ b/server/src/main/java/com/memoritta/server/model/Description.java
@@ -2,6 +2,7 @@ package com.memoritta.server.model;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.List;
@@ -10,6 +11,7 @@ import java.util.UUID;
 @Getter
 @Setter
 @Builder
+@NoArgsConstructor
 public class Description {
     private UUID id;
     private String note;

--- a/server/src/main/java/com/memoritta/server/model/FriendRelation.java
+++ b/server/src/main/java/com/memoritta/server/model/FriendRelation.java
@@ -2,6 +2,7 @@ package com.memoritta.server.model;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.UUID;
@@ -9,6 +10,7 @@ import java.util.UUID;
 @Getter
 @Setter
 @Builder
+@NoArgsConstructor
 public class FriendRelation {
     private UUID id;
     private UUID userId;

--- a/server/src/main/java/com/memoritta/server/model/Item.java
+++ b/server/src/main/java/com/memoritta/server/model/Item.java
@@ -2,6 +2,7 @@ package com.memoritta.server.model;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.Map;
@@ -11,6 +12,7 @@ import java.util.UUID;
 @Getter
 @Setter
 @Builder
+@NoArgsConstructor
 public class Item {
     private UUID id;
     private String name;

--- a/server/src/main/java/com/memoritta/server/model/PictureOfItem.java
+++ b/server/src/main/java/com/memoritta/server/model/PictureOfItem.java
@@ -2,6 +2,7 @@ package com.memoritta.server.model;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.UUID;
@@ -9,6 +10,7 @@ import java.util.UUID;
 @Getter
 @Setter
 @Builder
+@NoArgsConstructor
 public class PictureOfItem {
     private UUID id;
     private byte[] picture;

--- a/server/src/main/java/com/memoritta/server/model/Question.java
+++ b/server/src/main/java/com/memoritta/server/model/Question.java
@@ -2,6 +2,7 @@ package com.memoritta.server.model;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.UUID;
@@ -9,6 +10,7 @@ import java.util.UUID;
 @Getter
 @Setter
 @Builder
+@NoArgsConstructor
 public class Question {
     private UUID id;
     private UUID fromUserId;

--- a/server/src/main/java/com/memoritta/server/model/SearchSimilarRequest.java
+++ b/server/src/main/java/com/memoritta/server/model/SearchSimilarRequest.java
@@ -2,6 +2,7 @@ package com.memoritta.server.model;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.Map;
@@ -9,6 +10,7 @@ import java.util.Map;
 @Getter
 @Setter
 @Builder
+@NoArgsConstructor
 public class SearchSimilarRequest {
     private String id;
     private Map<String, String> parameters;

--- a/server/src/main/java/com/memoritta/server/model/TagSearchRequest.java
+++ b/server/src/main/java/com/memoritta/server/model/TagSearchRequest.java
@@ -2,6 +2,7 @@ package com.memoritta.server.model;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.List;
@@ -9,6 +10,7 @@ import java.util.List;
 @Getter
 @Setter
 @Builder
+@NoArgsConstructor
 public class TagSearchRequest {
     private List<String> tags;
     private boolean matchAll;

--- a/server/src/main/java/com/memoritta/server/model/User.java
+++ b/server/src/main/java/com/memoritta/server/model/User.java
@@ -2,6 +2,7 @@ package com.memoritta.server.model;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.UUID;
@@ -9,6 +10,7 @@ import java.util.UUID;
 @Setter
 @Getter
 @Builder
+@NoArgsConstructor
 public class User {
     private UUID id;
     private String nickname;


### PR DESCRIPTION
## Summary
- disable MapStruct builder processing in mappers to avoid missing property errors

## Testing
- `mvn -q -DskipTests clean package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6846e3b66958832795b4728ca19c44a0