### PR TITLE
Update question listing to return reference

### DIFF
--- a/server/src/main/java/com/memoritta/server/controller/QuestionController.java
+++ b/server/src/main/java/com/memoritta/server/controller/QuestionController.java
@@ -1,7 +1,7 @@
 package com.memoritta.server.controller;
 
 import com.memoritta.server.manager.QuestionManager;
-import com.memoritta.server.model.Question;
+import com.memoritta.server.model.QuestionRef;
 import com.memoritta.server.model.QuestionAudience;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -33,7 +33,7 @@ public class QuestionController {
 
     @GetMapping
     @Operation(summary = "List questions", description = "Lists questions for the given user")
-    public List<Question> listQuestions(
+    public List<QuestionRef> listQuestions(
             @RequestParam @Parameter(description = "ID of user to get questions for") String userId
     ) {
         return questionManager.listQuestionsForUser(UUID.fromString(userId));

--- a/server/src/main/java/com/memoritta/server/model/QuestionRef.java
+++ b/server/src/main/java/com/memoritta/server/model/QuestionRef.java
@@ -1,0 +1,17 @@
+package com.memoritta.server.model;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+public class QuestionRef {
+    private UUID id;
+    private Instant createdAt;
+    private String description;
+}

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -29,6 +29,10 @@ spring:
 serverConfig:
   version: "1.0.0"
 
+question:
+  ref:
+    description-max-length: 200
+
 management:
   endpoints:
     web:

--- a/server/src/test/java/com/memoritta/server/controller/QuestionControllerTest.java
+++ b/server/src/test/java/com/memoritta/server/controller/QuestionControllerTest.java
@@ -3,7 +3,7 @@ package com.memoritta.server.controller;
 import com.memoritta.server.client.QuestionRepository;
 import com.memoritta.server.dao.QuestionDao;
 import com.memoritta.server.manager.QuestionManager;
-import com.memoritta.server.model.Question;
+import com.memoritta.server.model.QuestionRef;
 import com.memoritta.server.model.QuestionAudience;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -68,7 +68,7 @@ class QuestionControllerTest {
                 .build();
         when(questionRepository.findAll()).thenReturn(List.of(direct, publicQ));
 
-        List<Question> result = questionController.listQuestions(userId.toString());
+        List<QuestionRef> result = questionController.listQuestions(userId.toString());
 
         assertThat(result).hasSize(2);
     }


### PR DESCRIPTION
## Summary
- add `QuestionRef` model
- list question references instead of full questions
- truncate description by configurable length
- update controller and tests

## Testing
- `mvn -q -pl server test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68471248bd708327882740df4c76deca