### PR TITLE
Add static credentials for photo uploads

### DIFF
--- a/frontend/src/AddView.jsx
+++ b/frontend/src/AddView.jsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState, useEffect } from 'react';
 import useBarcodeScanner from './hooks/useBarcodeScanner.js';
-import { BACKEND_URL } from './config.js';
+import { BACKEND_URL, AUTH_EMAIL, AUTH_PASSWORD } from './config.js';
 
 export default function AddView({ onBack = () => {} }) {
   const {
@@ -126,8 +126,10 @@ export default function AddView({ onBack = () => {} }) {
     formData.append('pictureBase64', dataUrl.split(',')[1]);
 
     try {
+      const token = btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`);
       await fetch(`${BACKEND_URL}/item`, {
         method: 'PUT',
+        headers: { Authorization: `Basic ${token}` },
         body: formData,
       });
       addDebug('Item sent to server');

--- a/frontend/src/AddView.test.jsx
+++ b/frontend/src/AddView.test.jsx
@@ -16,7 +16,7 @@ vi.mock('./hooks/useBarcodeScanner.js', () => ({
 }));
 
 import AddView from './AddView.jsx';
-import { BACKEND_URL } from './config.js';
+import { BACKEND_URL, AUTH_EMAIL, AUTH_PASSWORD } from './config.js';
 
 describe('AddView', () => {
   beforeEach(() => {
@@ -193,7 +193,12 @@ describe('AddView', () => {
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(
         `${BACKEND_URL}/item`,
-        expect.objectContaining({ method: 'PUT' })
+        expect.objectContaining({
+          method: 'PUT',
+          headers: expect.objectContaining({
+            Authorization: `Basic ${btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`)}`,
+          }),
+        })
       );
     });
 

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,1 +1,3 @@
 export const BACKEND_URL = 'https://memoritta.com/api';
+export const AUTH_EMAIL = 'admin';
+export const AUTH_PASSWORD = 'admin';


### PR DESCRIPTION
## Summary
- store default Basic Auth credentials in config
- use these credentials for photo uploads
- simplify store and login state
- update tests for static credentials

## Testing
- `npm install`
- `npx -y vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684f05bcf47c83279df8cde1911bf93c