### PR TITLE
Add icons to frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@zxing/browser": "^0.1.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-icons": "^5.5.0",
         "react-redux": "^9.2.0"
       },
       "devDependencies": {
@@ -3209,6 +3210,15 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@zxing/browser": "^0.1.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-icons": "^5.5.0",
     "react-redux": "^9.2.0"
   },
   "devDependencies": {

--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -1,4 +1,11 @@
 import React, { useState, useEffect } from 'react';
+import {
+  MdAdd,
+  MdCompareArrows,
+  MdHelpOutline,
+  MdQuestionAnswer,
+  MdGroup,
+} from 'react-icons/md';
 import { useDispatch, useSelector } from 'react-redux';
 import { setUserInfo, setCurrentView } from './store.js';
 
@@ -111,27 +118,27 @@ export default function LoginForm({ onLogin }) {
               </ul>
               <div>
                 <button onClick={() => dispatch(setCurrentView('add'))}>
-                  Add
+                  <MdAdd /> Add
                 </button>
               </div>
               <div>
                 <button onClick={() => dispatch(setCurrentView('compare'))}>
-                  Compare
+                  <MdCompareArrows /> Compare
                 </button>
               </div>
               <div>
                 <button onClick={() => dispatch(setCurrentView('ask'))}>
-                  Ask
+                  <MdHelpOutline /> Ask
                 </button>
               </div>
               <div>
                 <button onClick={() => dispatch(setCurrentView('questions'))}>
-                  Questions
+                  <MdQuestionAnswer /> Questions
                 </button>
               </div>
               <div>
                 <button onClick={() => dispatch(setCurrentView('friends'))}>
-                  Friends
+                  <MdGroup /> Friends
                 </button>
               </div>
             </>


### PR DESCRIPTION
## Summary
- install `react-icons`
- add icons to the navigation buttons in `LoginForm`

## Testing
- `npm test` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_684f12540c1c83279aae50739b96bf93