### PR TITLE
Add mobile mode detection

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,8 +2,10 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import LoginForm from './LoginForm.jsx';
 import store from './store.js';
+import useDeviceClass from './hooks/useDeviceClass.js';
 
 export default function App() {
+  useDeviceClass();
   return (
     <Provider store={store}>
       <div>

--- a/frontend/src/hooks/useDeviceClass.js
+++ b/frontend/src/hooks/useDeviceClass.js
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+
+export default function useDeviceClass() {
+  useEffect(() => {
+    function updateClass() {
+      if (typeof window === 'undefined') return;
+      const isMobile =
+        /Mobi|Android/i.test(navigator.userAgent) || window.innerWidth <= 600;
+      document.body.classList.toggle('mobile', isMobile);
+      document.body.classList.toggle('desktop', !isMobile);
+    }
+    updateClass();
+    window.addEventListener('resize', updateClass);
+    return () => window.removeEventListener('resize', updateClass);
+  }, []);
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -96,3 +96,8 @@ h1 {
   height: 240px;
   object-fit: cover;
 }
+
+body.mobile .login-form { max-width: 90%; }
+body.mobile h1 { font-size: 1.5rem; }
+body.desktop .login-form { max-width: 400px; }
+


### PR DESCRIPTION
## Summary
- detect desktop vs mobile screen and add `mobile` or `desktop` class to the body
- apply new classes to the React app
- style login form and headers for mobile mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f191f7a6883279c9915360b3e87c3