### PR TITLE
Add signup suggestion on failed login

### DIFF
--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -15,13 +15,14 @@ import Ask from './Ask.jsx';
 import Questions from './Questions.jsx';
 import Friends from './Friends.jsx';
 
-import { BACKEND_URL } from './config.js';
+import { BACKEND_URL, AUTH_EMAIL, AUTH_PASSWORD } from './config.js';
 
 export default function LoginForm({ onLogin }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [remember, setRemember] = useState(false);
   const [message, setMessage] = useState('');
+  const [showSignup, setShowSignup] = useState(false);
   const userInfo = useSelector((state) => state.user.userInfo);
   const currentView = useSelector((state) => state.user.currentView);
   const dispatch = useDispatch();
@@ -64,7 +65,32 @@ export default function LoginForm({ onLogin }) {
         onLogin(data.user);
       }
     } catch (err) {
-      setMessage('Login error');
+      setMessage('Login failed. You can create an account.');
+      setShowSignup(true);
+    }
+  }
+
+  async function handleCreateAccount() {
+    setMessage('');
+    try {
+      const nickname = email.split('@')[0] || 'User';
+      const token = btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`);
+      const params = new URLSearchParams({ email, password, nickname });
+      const response = await fetch(`${BACKEND_URL}/user`, {
+        method: 'PUT',
+        headers: {
+          Authorization: `Basic ${token}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: params,
+      });
+      if (!response.ok) {
+        throw new Error('signup failed');
+      }
+      setMessage('Account created. Please log in.');
+      setShowSignup(false);
+    } catch (err) {
+      setMessage('Signup error');
     }
   }
 
@@ -102,6 +128,11 @@ export default function LoginForm({ onLogin }) {
           </label>
           <button type="submit">Login</button>
           {message && !userInfo && <p>{message}</p>}
+          {showSignup && !userInfo && (
+            <button type="button" onClick={handleCreateAccount}>
+              Create account
+            </button>
+          )}
         </>
       )}
       {userInfo && (

--- a/frontend/src/LoginForm.test.jsx
+++ b/frontend/src/LoginForm.test.jsx
@@ -100,6 +100,34 @@ describe('LoginForm', () => {
     expect(screen.getByTestId('password-input')).toHaveValue('bar');
   });
 
+  it('shows signup option when login fails and creates account', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false })
+      .mockResolvedValueOnce({ ok: true });
+
+    renderWithProvider(<LoginForm />);
+    fireEvent.change(screen.getByTestId('email-input'), {
+      target: { value: 'new@example.com' },
+    });
+    fireEvent.change(screen.getByTestId('password-input'), {
+      target: { value: 'secret' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+
+    await screen.findByText(/login failed/i);
+    const signupButton = screen.getByRole('button', { name: /create account/i });
+    expect(signupButton).toBeInTheDocument();
+
+    fireEvent.click(signupButton);
+    await screen.findByText(/account created/i);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${BACKEND_URL}/user`,
+      expect.objectContaining({ method: 'PUT' })
+    );
+  });
+
   it(
     'shows proper view when a button is clicked',
     { timeout: 10000 },


### PR DESCRIPTION
## Summary
- show signup option when login fails
- support signup request with basic auth
- test signup flow in LoginForm

## Testing
- `npm test --silent`
- `mvn -q test -pl server` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f4b0954e88327b56c5a2f542b35cd