### PR TITLE
Add signup suggestion on failed login

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ This project was born from the need for:
    git clone https://github.com/TOlchawa/yapp
    ```
 
+Run `scripts/setup-maven.sh` to install Maven if needed.
+
 ### Camera Preview
 The web camera works only over HTTPS or on `localhost`.
 Give the browser permission to use the camera.

--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -15,13 +15,14 @@ import Ask from './Ask.jsx';
 import Questions from './Questions.jsx';
 import Friends from './Friends.jsx';
 
-import { BACKEND_URL } from './config.js';
+import { BACKEND_URL, AUTH_EMAIL, AUTH_PASSWORD } from './config.js';
 
 export default function LoginForm({ onLogin }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [remember, setRemember] = useState(false);
   const [message, setMessage] = useState('');
+  const [showSignup, setShowSignup] = useState(false);
   const userInfo = useSelector((state) => state.user.userInfo);
   const currentView = useSelector((state) => state.user.currentView);
   const dispatch = useDispatch();
@@ -64,7 +65,32 @@ export default function LoginForm({ onLogin }) {
         onLogin(data.user);
       }
     } catch (err) {
-      setMessage('Login error');
+      setMessage('Login failed. You can create an account.');
+      setShowSignup(true);
+    }
+  }
+
+  async function handleCreateAccount() {
+    setMessage('');
+    try {
+      const nickname = email.split('@')[0] || 'User';
+      const token = btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`);
+      const params = new URLSearchParams({ email, password, nickname });
+      const response = await fetch(`${BACKEND_URL}/user`, {
+        method: 'PUT',
+        headers: {
+          Authorization: `Basic ${token}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: params,
+      });
+      if (!response.ok) {
+        throw new Error('signup failed');
+      }
+      setMessage('Account created. Please log in.');
+      setShowSignup(false);
+    } catch (err) {
+      setMessage('Signup error');
     }
   }
 
@@ -102,6 +128,11 @@ export default function LoginForm({ onLogin }) {
           </label>
           <button type="submit">Login</button>
           {message && !userInfo && <p>{message}</p>}
+          {showSignup && !userInfo && (
+            <button type="button" onClick={handleCreateAccount}>
+              Create account
+            </button>
+          )}
         </>
       )}
       {userInfo && (

--- a/frontend/src/LoginForm.test.jsx
+++ b/frontend/src/LoginForm.test.jsx
@@ -100,6 +100,34 @@ describe('LoginForm', () => {
     expect(screen.getByTestId('password-input')).toHaveValue('bar');
   });
 
+  it('shows signup option when login fails and creates account', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false })
+      .mockResolvedValueOnce({ ok: true });
+
+    renderWithProvider(<LoginForm />);
+    fireEvent.change(screen.getByTestId('email-input'), {
+      target: { value: 'new@example.com' },
+    });
+    fireEvent.change(screen.getByTestId('password-input'), {
+      target: { value: 'secret' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+
+    await screen.findByText(/login failed/i);
+    const signupButton = screen.getByRole('button', { name: /create account/i });
+    expect(signupButton).toBeInTheDocument();
+
+    fireEvent.click(signupButton);
+    await screen.findByText(/account created/i);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${BACKEND_URL}/user`,
+      expect.objectContaining({ method: 'PUT' })
+    );
+  });
+
   it(
     'shows proper view when a button is clicked',
     { timeout: 10000 },

--- a/scripts/setup-maven.sh
+++ b/scripts/setup-maven.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Simple script to install Maven using apt-get.
+# Run this if Maven is missing.
+set -e
+
+if command -v mvn >/dev/null 2>&1; then
+  echo "Maven already installed"
+  exit 0
+fi
+
+sudo apt-get update && sudo apt-get install -y maven


### PR DESCRIPTION
## Summary
- show signup option when login fails
- support signup request with basic auth
- test signup flow in LoginForm
- add setup script for Maven

## Testing
- `npm test --silent`
- `mvn -q test -pl server` *(fails: repository unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684f4b0954e88327b56c5a2f542b35cd