### PR TITLE
Add password visibility toggle

### DIFF
--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -5,6 +5,8 @@ import {
   MdHelpOutline,
   MdQuestionAnswer,
   MdGroup,
+  MdVisibility,
+  MdVisibilityOff,
 } from 'react-icons/md';
 import { useDispatch, useSelector } from 'react-redux';
 import { setUserInfo, setCurrentView } from './store.js';
@@ -23,6 +25,7 @@ export default function LoginForm({ onLogin }) {
   const [remember, setRemember] = useState(false);
   const [message, setMessage] = useState('');
   const [showSignup, setShowSignup] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
   const userInfo = useSelector((state) => state.user.userInfo);
   const currentView = useSelector((state) => state.user.currentView);
   const dispatch = useDispatch();
@@ -110,12 +113,22 @@ export default function LoginForm({ onLogin }) {
           </label>
           <label>
             Password
-            <input
-              data-testid="password-input"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-            />
+            <span className="password-container">
+              <input
+                data-testid="password-input"
+                type={showPassword ? 'text' : 'password'}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
+              <button
+                type="button"
+                className="password-toggle"
+                aria-label={showPassword ? 'Hide password' : 'Show password'}
+                onClick={() => setShowPassword((prev) => !prev)}
+              >
+                {showPassword ? <MdVisibilityOff /> : <MdVisibility />}
+              </button>
+            </span>
           </label>
           <label>
             <input

--- a/frontend/src/LoginForm.test.jsx
+++ b/frontend/src/LoginForm.test.jsx
@@ -20,6 +20,19 @@ describe('LoginForm', () => {
     expect(screen.getByTestId('remember-checkbox')).toBeInTheDocument();
   });
 
+  it('toggles password visibility', () => {
+    renderWithProvider(<LoginForm />);
+    const input = screen.getByTestId('password-input');
+    const toggle = screen.getByRole('button', { name: /show password/i });
+    expect(input).toHaveAttribute('type', 'password');
+    fireEvent.click(toggle);
+    expect(input).toHaveAttribute('type', 'text');
+    expect(toggle).toHaveAccessibleName('Hide password');
+    fireEvent.click(toggle);
+    expect(input).toHaveAttribute('type', 'password');
+    expect(toggle).toHaveAccessibleName('Show password');
+  });
+
   it('calls fetch with credentials and shows user info', async () => {
     const mockResponse = {
       user: { nickname: 'nickname1', email: 'user@example.com', id: '1' },

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -101,3 +101,15 @@ body.mobile .login-form { max-width: 90%; }
 body.mobile h1 { font-size: 1.5rem; }
 body.desktop .login-form { max-width: 400px; }
 
+.password-container {
+  display: flex;
+  align-items: center;
+}
+
+.password-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0 0.25rem;
+}
+


### PR DESCRIPTION
## Summary
- show or hide password with a button
- style the new eye icon
- test the new toggle

## Testing
- `npm test`
- `mvn -q -f server/pom.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684f971ee678832792ada5c2549c64a6