### PR TITLE
Add direct Swagger UI link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,5 @@ npm run format
 ## API Documentation
 You can explore the REST API using the online Swagger UI:
 [https://memoritta.com/swagger-ui/index.html](https://memoritta.com/swagger-ui/index.html)
+
+To open the Swagger UI directly, visit https://memoritta.com/swagger-ui/index.html.


### PR DESCRIPTION
## Summary
- document how to open Swagger UI directly

## Testing
- `mvn -q -pl server test` *(fails: Non-resolvable parent POM)*
- `npm test` in `frontend` *(fails: vitest not found)*
- `npm install --silent` *(no output due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684f988ec22c8327a27195f3d87e568c