### PR TITLE
Add Search feature

### DIFF
--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import {
   MdAdd,
   MdCompareArrows,
+  MdSearch,
   MdHelpOutline,
   MdQuestionAnswer,
   MdGroup,
@@ -11,6 +12,7 @@ import { setUserInfo, setCurrentView } from './store.js';
 
 import AddView from './AddView.jsx';
 import Compare from './Compare.jsx';
+import Search from './Search.jsx';
 import Ask from './Ask.jsx';
 import Questions from './Questions.jsx';
 import Friends from './Friends.jsx';
@@ -158,6 +160,11 @@ export default function LoginForm({ onLogin }) {
                 </button>
               </div>
               <div>
+                <button onClick={() => dispatch(setCurrentView('search'))}>
+                  <MdSearch /> Search
+                </button>
+              </div>
+              <div>
                 <button onClick={() => dispatch(setCurrentView('ask'))}>
                   <MdHelpOutline /> Ask
                 </button>
@@ -179,6 +186,9 @@ export default function LoginForm({ onLogin }) {
           )}
           {currentView === 'compare' && (
             <Compare onBack={() => dispatch(setCurrentView(null))} />
+          )}
+          {currentView === 'search' && (
+            <Search onBack={() => dispatch(setCurrentView(null))} />
           )}
           {currentView === 'ask' && (
             <Ask onBack={() => dispatch(setCurrentView(null))} />

--- a/frontend/src/LoginForm.test.jsx
+++ b/frontend/src/LoginForm.test.jsx
@@ -57,6 +57,7 @@ describe('LoginForm', () => {
     expect(screen.getByText(/ID: 1/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Add' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Compare' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Search' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Ask' })).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: 'Questions' })
@@ -161,6 +162,10 @@ describe('LoginForm', () => {
       await screen.findByRole('button', { name: 'Compare' });
       fireEvent.click(screen.getByRole('button', { name: 'Compare' }));
       await screen.findByRole('heading', { name: 'Compare' });
+      fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+      await screen.findByRole('button', { name: 'Search' });
+      fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+      await screen.findByRole('heading', { name: 'Search' });
       fireEvent.click(screen.getByRole('button', { name: 'Back' }));
       await screen.findByRole('button', { name: 'Ask' });
       fireEvent.click(screen.getByRole('button', { name: 'Ask' }));

--- a/frontend/src/Search.jsx
+++ b/frontend/src/Search.jsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+import { BACKEND_URL } from './config.js';
+
+export default function Search({ onBack = () => {} }) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState([]);
+
+  async function handleSearch() {
+    const tags = query
+      .split(',')
+      .map((t) => t.trim())
+      .filter((t) => t);
+    try {
+      const response = await fetch(`${BACKEND_URL}/items/tags`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tags, matchAll: false }),
+      });
+      if (response.ok) {
+        const data = await response.json();
+        setResults(data);
+      }
+    } catch (err) {
+      // Ignore errors for now
+    }
+  }
+
+  return (
+    <div>
+      <div className="view-header">
+        <h1>Search</h1>
+        <button type="button" className="back-button" onClick={onBack}>
+          Back
+        </button>
+      </div>
+      <input
+        data-testid="search-input"
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+      <button type="button" onClick={handleSearch}>
+        Search
+      </button>
+      <ul>
+        {results.map((item) => (
+          <li key={item.id}>{item.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/Search.test.jsx
+++ b/frontend/src/Search.test.jsx
@@ -1,0 +1,30 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import Search from './Search.jsx';
+import { BACKEND_URL } from './config.js';
+
+describe('Search view', () => {
+  it('shows Search title', () => {
+    render(<Search />);
+    expect(screen.getByRole('heading', { name: 'Search' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
+  });
+
+  it('fetches items on search', async () => {
+    const items = [{ id: '1', name: 'Item1' }];
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(items) })
+    );
+    render(<Search />);
+    fireEvent.change(screen.getByTestId('search-input'), {
+      target: { value: 'tag1' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+    await screen.findByText('Item1');
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${BACKEND_URL}/items/tags`,
+      expect.any(Object)
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add Search view for querying items by tags
- add button to open Search view
- test Search view and update login flow tests

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684f97ff4c888327967cab98f2cebff4