### PR TITLE
Show item UUIDs in Search

### DIFF
--- a/frontend/src/LoginForm.test.jsx
+++ b/frontend/src/LoginForm.test.jsx
@@ -150,12 +150,22 @@ describe('LoginForm', () => {
         user: { nickname: 'Nick', email: 'user@example.com', id: '1' },
         jwtToken: 'token',
       };
-      global.fetch = vi.fn(() =>
-        Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve(mockResponse),
-        })
-      );
+      const items = ['id1'];
+      global.fetch = vi.fn((url) => {
+        if (url.endsWith('/items/user')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(items),
+          });
+        }
+        if (url.endsWith('/user')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(mockResponse),
+          });
+        }
+        return Promise.resolve({ ok: false });
+      });
 
       renderWithProvider(<LoginForm />);
       fireEvent.change(screen.getByTestId('email-input'), {

--- a/frontend/src/Search.jsx
+++ b/frontend/src/Search.jsx
@@ -1,29 +1,25 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { BACKEND_URL } from './config.js';
 
 export default function Search({ onBack = () => {} }) {
-  const [query, setQuery] = useState('');
-  const [results, setResults] = useState([]);
+  const [itemIds, setItemIds] = useState([]);
 
-  async function handleSearch() {
-    const tags = query
-      .split(',')
-      .map((t) => t.trim())
-      .filter((t) => t);
-    try {
-      const response = await fetch(`${BACKEND_URL}/items/tags`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ tags, matchAll: false }),
-      });
-      if (response.ok) {
-        const data = await response.json();
-        setResults(data);
+  useEffect(() => {
+    async function fetchItems() {
+      try {
+        const response = await fetch(`${BACKEND_URL}/items/user`, {
+          method: 'POST',
+        });
+        if (response.ok) {
+          const data = await response.json();
+          setItemIds(data);
+        }
+      } catch (err) {
+        // Ignore errors for now
       }
-    } catch (err) {
-      // Ignore errors for now
     }
-  }
+    fetchItems();
+  }, []);
 
   return (
     <div>
@@ -33,18 +29,9 @@ export default function Search({ onBack = () => {} }) {
           Back
         </button>
       </div>
-      <input
-        data-testid="search-input"
-        type="text"
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-      />
-      <button type="button" onClick={handleSearch}>
-        Search
-      </button>
       <ul>
-        {results.map((item) => (
-          <li key={item.id}>{item.name}</li>
+        {itemIds.map((id) => (
+          <li key={id}>{id}</li>
         ))}
       </ul>
     </div>

--- a/frontend/src/Search.test.jsx
+++ b/frontend/src/Search.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import Search from './Search.jsx';
@@ -11,20 +11,16 @@ describe('Search view', () => {
     expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
   });
 
-  it('fetches items on search', async () => {
-    const items = [{ id: '1', name: 'Item1' }];
+  it('loads item IDs on mount', async () => {
+    const ids = ['1', '2'];
     global.fetch = vi.fn(() =>
-      Promise.resolve({ ok: true, json: () => Promise.resolve(items) })
+      Promise.resolve({ ok: true, json: () => Promise.resolve(ids) })
     );
     render(<Search />);
-    fireEvent.change(screen.getByTestId('search-input'), {
-      target: { value: 'tag1' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
-    await screen.findByText('Item1');
+    await screen.findByText('1');
     expect(global.fetch).toHaveBeenCalledWith(
-      `${BACKEND_URL}/items/tags`,
-      expect.any(Object)
+      `${BACKEND_URL}/items/user`,
+      expect.objectContaining({ method: 'POST' })
     );
   });
 });


### PR DESCRIPTION
## Summary
- fetch items from `/items/user` in the Search view
- render UUID list instead of name list
- update Search tests for new behaviour
- adjust LoginForm test to mock both `/user` and `/items/user` endpoints

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684fa7b525ec8327973346c749f05860