### PR TITLE
Automated restart after CI tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -74,3 +74,18 @@ jobs:
         if: always()
         run: |
           kill $(cat server.pid) || true
+
+      - name: Install sshpass
+        run: sudo apt-get update && sudo apt-get install -y sshpass
+
+      - name: Restart backend and frontend
+        if: success()
+        env:
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_PASSWORD: ${{ secrets.SSH_PASSWORD }}
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SERVER_HOME: ${{ secrets.SERVER_HOME }}
+          FRONTEND_HOME: ${{ secrets.FRONTEND_HOME }}
+          SERVER_SCRIPT: ${{ secrets.SERVER_SCRIPT }}
+          FRONTEND_SCRIPT: ${{ secrets.FRONTEND_SCRIPT }}
+        run: ./scripts/restart-services.sh

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -84,3 +84,18 @@ jobs:
         run: |
           cd server
           mvn test -Dtest=*IT
+
+      - name: Install sshpass
+        run: sudo apt-get update && sudo apt-get install -y sshpass
+
+      - name: Restart backend and frontend
+        if: success()
+        env:
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_PASSWORD: ${{ secrets.SSH_PASSWORD }}
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SERVER_HOME: ${{ secrets.SERVER_HOME }}
+          FRONTEND_HOME: ${{ secrets.FRONTEND_HOME }}
+          SERVER_SCRIPT: ${{ secrets.SERVER_SCRIPT }}
+          FRONTEND_SCRIPT: ${{ secrets.FRONTEND_SCRIPT }}
+        run: ./scripts/restart-services.sh

--- a/scripts/restart-services.sh
+++ b/scripts/restart-services.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Restart backend and frontend using remote scripts.
+set -euo pipefail
+
+: "${SERVER_HOME?Environment variable SERVER_HOME is required}"
+: "${FRONTEND_HOME?Environment variable FRONTEND_HOME is required}"
+: "${SERVER_SCRIPT?Environment variable SERVER_SCRIPT is required}"
+: "${FRONTEND_SCRIPT?Environment variable FRONTEND_SCRIPT is required}"
+: "${SSH_USER?Environment variable SSH_USER is required}"
+: "${SSH_PASSWORD?Environment variable SSH_PASSWORD is required}"
+: "${SSH_HOST?Environment variable SSH_HOST is required}"
+
+sshpass -p "$SSH_PASSWORD" ssh -o StrictHostKeyChecking=no "$SSH_USER@$SSH_HOST" <<ENDSSH
+cd "$SERVER_HOME"
+./"$SERVER_SCRIPT"
+cd "$FRONTEND_HOME"
+./"$FRONTEND_SCRIPT"
+ENDSSH


### PR DESCRIPTION
## Summary
- add script to restart backend and frontend remotely
- install sshpass and call restart script in integration workflow
- do the same in maven workflow

## Testing
- `bash scripts/setup-maven.sh`
- `mvn -B test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851a3b45a6c8327a71aaef0d23d719e