### PR TITLE
Configure PROD environment for deployment workflows

### DIFF
--- a/.github/workflows/deploy-on-merge.yml
+++ b/.github/workflows/deploy-on-merge.yml
@@ -20,8 +20,8 @@ jobs:
           SSH_USER: ${{ secrets.SSH_USER }}
           SSH_PASSWORD: ${{ secrets.SSH_PASSWORD }}
           SSH_HOST: ${{ secrets.SSH_HOST }}
-          SERVER_HOME: ${{ secrets.SERVER_HOME }}
-          FRONTEND_HOME: ${{ secrets.FRONTEND_HOME }}
-          SERVER_SCRIPT: ${{ secrets.SERVER_SCRIPT }}
-          FRONTEND_SCRIPT: ${{ secrets.FRONTEND_SCRIPT }}
+          SERVER_HOME: ${{ vars.SERVER_HOME }}
+          FRONTEND_HOME: ${{ vars.FRONTEND_HOME }}
+          SERVER_SCRIPT: ${{ vars.SERVER_SCRIPT }}
+          FRONTEND_SCRIPT: ${{ vars.FRONTEND_SCRIPT }}
         run: ./scripts/restart-services.sh

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -21,8 +21,8 @@ jobs:
           SSH_USER: ${{ secrets.SSH_USER }}
           SSH_PASSWORD: ${{ secrets.SSH_PASSWORD }}
           SSH_HOST: ${{ secrets.SSH_HOST }}
-          SERVER_HOME: ${{ secrets.SERVER_HOME }}
-          FRONTEND_HOME: ${{ secrets.FRONTEND_HOME }}
-          SERVER_SCRIPT: ${{ secrets.SERVER_SCRIPT }}
-          FRONTEND_SCRIPT: ${{ secrets.FRONTEND_SCRIPT }}
+          SERVER_HOME: ${{ vars.SERVER_HOME }}
+          FRONTEND_HOME: ${{ vars.FRONTEND_HOME }}
+          SERVER_SCRIPT: ${{ vars.SERVER_SCRIPT }}
+          FRONTEND_SCRIPT: ${{ vars.FRONTEND_SCRIPT }}
         run: ./scripts/restart-services.sh

--- a/README.md
+++ b/README.md
@@ -70,13 +70,14 @@ The project uses two workflows to deploy the backend and frontend:
 Both workflows expect an environment called `PROD`. To configure it:
 
 1. In your repository, open **Settings → Environments** and create `PROD`.
-2. Inside this environment add the following secrets:
+2. In `PROD` add these *secrets*:
    - `SSH_USER`
    - `SSH_PASSWORD`
    - `SSH_HOST`
+3. Add these *variables*:
    - `SERVER_HOME`
    - `FRONTEND_HOME`
    - `SERVER_SCRIPT`
    - `FRONTEND_SCRIPT`
 
-The workflows read these secrets and pass them to `scripts/restart-services.sh` to restart the services on your server.
+The workflows read the secrets and variables and pass them to `scripts/restart-services.sh` to restart the services on your server.


### PR DESCRIPTION
## Summary
- use the `PROD` environment in deployment workflows
- document how to configure deployment secrets

## Testing
- `scripts/setup-maven.sh`
- `mvn -q -pl server -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6851aec311748327ba3e9c50fbdab94a