### PR TITLE
Add basic auth to search view

### DIFF
--- a/frontend/src/Search.jsx
+++ b/frontend/src/Search.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { BACKEND_URL } from './config.js';
+import { BACKEND_URL, AUTH_EMAIL, AUTH_PASSWORD } from './config.js';
 
 export default function Search({ onBack = () => {} }) {
   const [itemIds, setItemIds] = useState([]);
@@ -7,8 +7,10 @@ export default function Search({ onBack = () => {} }) {
   useEffect(() => {
     async function fetchItems() {
       try {
+        const token = btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`);
         const response = await fetch(`${BACKEND_URL}/items/user`, {
           method: 'POST',
+          headers: { Authorization: `Basic ${token}` },
         });
         if (response.ok) {
           const data = await response.json();

--- a/frontend/src/Search.test.jsx
+++ b/frontend/src/Search.test.jsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import Search from './Search.jsx';
-import { BACKEND_URL } from './config.js';
+import { BACKEND_URL, AUTH_EMAIL, AUTH_PASSWORD } from './config.js';
 
 describe('Search view', () => {
   it('shows Search title', () => {
@@ -20,7 +20,12 @@ describe('Search view', () => {
     await screen.findByText('1');
     expect(global.fetch).toHaveBeenCalledWith(
       `${BACKEND_URL}/items/user`,
-      expect.objectContaining({ method: 'POST' })
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: `Basic ${btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`)}`,
+        }),
+      })
     );
   });
 });


### PR DESCRIPTION
## Summary
- send Basic auth header when fetching `/items/user`
- update tests for Search view

## Testing
- `npm install --silent` in `frontend`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685108614a2083278f0b62b4ab5ee341