### PR TITLE
Update Ask view layout for mobile and desktop

### DIFF
--- a/frontend/src/Ask.jsx
+++ b/frontend/src/Ask.jsx
@@ -7,7 +7,7 @@ export default function Ask({ onBack = () => {} }) {
     // Add API call or other logic here later
   }
   return (
-    <div>
+    <div className="ask-form" data-testid="ask-form">
       <div className="view-header">
         <h1>Ask</h1>
         <button type="button" className="back-button" onClick={onBack}>
@@ -15,6 +15,7 @@ export default function Ask({ onBack = () => {} }) {
         </button>
       </div>
       <textarea
+        className="ask-textarea"
         data-testid="ask-textarea"
         rows={5}
         value={question}

--- a/frontend/src/Ask.test.jsx
+++ b/frontend/src/Ask.test.jsx
@@ -11,6 +11,7 @@ describe('Ask view', () => {
 
   it('shows a textarea and Ask button', () => {
     render(<Ask />);
+    expect(screen.getByTestId('ask-form')).toBeInTheDocument();
     expect(screen.getByTestId('ask-textarea')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Ask' })).toBeInTheDocument();
   });

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -124,3 +124,21 @@ body.desktop .login-form { max-width: 400px; }
   font-size: 0.9rem;
 }
 
+/* Ask view layout */
+.ask-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.ask-textarea {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+body.desktop .ask-form {
+  max-width: 600px;
+}
+


### PR DESCRIPTION
## Summary
- adjust `Ask` view markup to use a container
- add tests for the new container
- style Ask view for mobile and desktop widths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851ba046f648327a01bcbe782ad0b7e