### PR TITLE
Add item details view

### DIFF
--- a/frontend/src/ItemDetails.jsx
+++ b/frontend/src/ItemDetails.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+export default function ItemDetails({ item, onBack = () => {} }) {
+  if (!item) {
+    return null;
+  }
+  const { name, description } = item;
+  const barcode = description && description.barcode;
+  const note = description && description.note;
+  const picture = description && description.pictures && description.pictures[0];
+  let imgSrc = null;
+  if (picture && picture.picture) {
+    const data = picture.picture;
+    if (data.startsWith('data:')) {
+      imgSrc = data;
+    } else {
+      imgSrc = `data:image/jpeg;base64,${data}`;
+    }
+  }
+  return (
+    <div>
+      <div className="view-header">
+        <h1>Item details</h1>
+        <button type="button" className="back-button" onClick={onBack}>
+          Back
+        </button>
+      </div>
+      <h2>{name}</h2>
+      {barcode && <p>Barcode: {barcode}</p>}
+      {note && <p>{note}</p>}
+      {imgSrc && <img src={imgSrc} alt="Item" />}
+    </div>
+  );
+}

--- a/frontend/src/ItemDetails.test.jsx
+++ b/frontend/src/ItemDetails.test.jsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ItemDetails from './ItemDetails.jsx';
+
+const sampleItem = {
+  name: 'Beer',
+  description: {
+    barcode: '123',
+    note: 'note',
+    pictures: [{ picture: 'imgdata' }],
+  },
+};
+
+describe('ItemDetails view', () => {
+  it('shows title and item info', () => {
+    render(<ItemDetails item={sampleItem} />);
+    expect(screen.getByRole('heading', { name: 'Item details' })).toBeInTheDocument();
+    expect(screen.getByText('Beer')).toBeInTheDocument();
+    expect(screen.getByText('Barcode: 123')).toBeInTheDocument();
+    expect(screen.getByAltText('Item')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/Search.jsx
+++ b/frontend/src/Search.jsx
@@ -1,10 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import { FaBarcode } from 'react-icons/fa';
 import { BACKEND_URL, AUTH_EMAIL, AUTH_PASSWORD } from './config.js';
+import ItemDetails from './ItemDetails.jsx';
 
 export default function Search({ onBack = () => {} }) {
   const [itemIds, setItemIds] = useState([]);
   const [details, setDetails] = useState({});
+  const [selectedId, setSelectedId] = useState(null);
 
   useEffect(() => {
     async function fetchItems() {
@@ -24,6 +26,31 @@ export default function Search({ onBack = () => {} }) {
     }
     fetchItems();
   }, []);
+
+  useEffect(() => {
+    if (!selectedId || details[selectedId]) {
+      return;
+    }
+    let cancelled = false;
+    async function fetchDetail() {
+      try {
+        const token = btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`);
+        const resp = await fetch(`${BACKEND_URL}/item?id=${selectedId}`, {
+          headers: { Authorization: `Basic ${token}` },
+        });
+        if (!cancelled && resp.ok) {
+          const data = await resp.json();
+          setDetails((prev) => ({ ...prev, [selectedId]: data }));
+        }
+      } catch (err) {
+        // Ignore errors
+      }
+    }
+    fetchDetail();
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedId]);
 
   useEffect(() => {
     if (itemIds.length === 0) {
@@ -55,6 +82,15 @@ export default function Search({ onBack = () => {} }) {
     };
   }, [itemIds]);
 
+  if (selectedId) {
+    return (
+      <ItemDetails
+        item={details[selectedId]}
+        onBack={() => setSelectedId(null)}
+      />
+    );
+  }
+
   return (
     <div>
       <div className="view-header">
@@ -70,7 +106,7 @@ export default function Search({ onBack = () => {} }) {
           const hasBarcode =
             info && info.description && info.description.barcode;
           return (
-            <li key={id}>
+            <li key={id} onClick={() => setSelectedId(id)}>
               {name}
               {hasBarcode && <FaBarcode aria-label="barcode" />}
             </li>

--- a/frontend/src/Search.test.jsx
+++ b/frontend/src/Search.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import Search from './Search.jsx';
@@ -56,5 +56,28 @@ describe('Search view', () => {
       })
     );
     expect(screen.getByLabelText('barcode')).toBeInTheDocument();
+  });
+
+  it('opens details view on item click without refetch', async () => {
+    const ids = ['123'];
+    const item = {
+      name: 'Beer',
+      description: { barcode: '789', pictures: [{ picture: 'img' }] },
+    };
+    global.fetch = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(ids) })
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(item) })
+      );
+    render(<Search />);
+    const itemEl = await screen.findByText('Beer');
+    global.fetch.mockClear();
+    fireEvent.click(itemEl);
+    await screen.findByRole('heading', { name: 'Item details' });
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(screen.getByText('Barcode: 789')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add ItemDetails view to show item data and image
- integrate ItemDetails into Search and avoid extra backend calls
- add tests for the new view and updated Search

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6851d27ffbe483278909d15779bed35e