### PR TITLE
Add footers with back buttons and item details

### DIFF
--- a/frontend/src/AddView.jsx
+++ b/frontend/src/AddView.jsx
@@ -226,6 +226,11 @@ export default function AddView({ onBack = () => {} }) {
           data-testid="debug-output"
         />
       </div>
+      <footer className="view-footer">
+        <button type="button" className="back-button" onClick={onBack}>
+          Back
+        </button>
+      </footer>
     </div>
   );
 }

--- a/frontend/src/AddView.test.jsx
+++ b/frontend/src/AddView.test.jsx
@@ -45,7 +45,7 @@ describe('AddView', () => {
   it('shows Add title', () => {
     render(<AddView />);
     expect(screen.getByRole('heading', { name: 'Add' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Back' })).toHaveLength(2);
   });
 
   it('enables camera and shows take photo button', async () => {

--- a/frontend/src/Ask.jsx
+++ b/frontend/src/Ask.jsx
@@ -24,6 +24,11 @@ export default function Ask({ onBack = () => {} }) {
       <button type="button" onClick={handleAsk}>
         Ask
       </button>
+      <footer className="view-footer">
+        <button type="button" className="back-button" onClick={onBack}>
+          Back
+        </button>
+      </footer>
     </div>
   );
 }

--- a/frontend/src/Ask.test.jsx
+++ b/frontend/src/Ask.test.jsx
@@ -6,7 +6,7 @@ describe('Ask view', () => {
   it('shows the Ask title', () => {
     render(<Ask />);
     expect(screen.getByRole('heading', { name: 'Ask' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Back' })).toHaveLength(2);
   });
 
   it('shows a textarea and Ask button', () => {

--- a/frontend/src/Compare.jsx
+++ b/frontend/src/Compare.jsx
@@ -9,6 +9,11 @@ export default function Compare({ onBack = () => {} }) {
           Back
         </button>
       </div>
+      <footer className="view-footer">
+        <button type="button" className="back-button" onClick={onBack}>
+          Back
+        </button>
+      </footer>
     </div>
   );
 }

--- a/frontend/src/Compare.test.jsx
+++ b/frontend/src/Compare.test.jsx
@@ -8,6 +8,6 @@ describe('Compare', () => {
     expect(
       screen.getByRole('heading', { name: 'Compare' })
     ).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Back' })).toHaveLength(2);
   });
 });

--- a/frontend/src/Friends.jsx
+++ b/frontend/src/Friends.jsx
@@ -9,6 +9,11 @@ export default function Friends({ onBack = () => {} }) {
           Back
         </button>
       </div>
+      <footer className="view-footer">
+        <button type="button" className="back-button" onClick={onBack}>
+          Back
+        </button>
+      </footer>
     </div>
   );
 }

--- a/frontend/src/Friends.test.jsx
+++ b/frontend/src/Friends.test.jsx
@@ -8,6 +8,6 @@ describe('Friends component', () => {
     expect(
       screen.getByRole('heading', { level: 1, name: 'Friends' })
     ).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Back' })).toHaveLength(2);
   });
 });

--- a/frontend/src/ItemDetails.jsx
+++ b/frontend/src/ItemDetails.jsx
@@ -1,0 +1,54 @@
+import React, { useState, useEffect } from 'react';
+import { FaBarcode } from 'react-icons/fa';
+import { BACKEND_URL, AUTH_EMAIL, AUTH_PASSWORD } from './config.js';
+
+export default function ItemDetails({ id, info, onBack = () => {}, onUpdate = () => {} }) {
+  const [data, setData] = useState(info || null);
+
+  useEffect(() => {
+    if (data) return;
+    async function load() {
+      try {
+        const token = btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`);
+        const resp = await fetch(`${BACKEND_URL}/item?id=${id}`, {
+          headers: { Authorization: `Basic ${token}` },
+        });
+        if (resp.ok) {
+          const result = await resp.json();
+          setData(result);
+          onUpdate(result);
+        }
+      } catch (err) {
+        // ignore errors
+      }
+    }
+    load();
+  }, [id]);
+
+  const name = data && data.name ? data.name : id;
+  const barcode = data && data.description && data.description.barcode;
+
+  return (
+    <div>
+      <div className="view-header">
+        <h1>Item details</h1>
+        <button type="button" className="back-button" onClick={onBack}>
+          Back
+        </button>
+      </div>
+      <div>
+        <p>{name}</p>
+        {barcode && (
+          <p>
+            <FaBarcode aria-label="barcode" /> {barcode}
+          </p>
+        )}
+      </div>
+      <footer className="view-footer">
+        <button type="button" className="back-button" onClick={onBack}>
+          Back
+        </button>
+      </footer>
+    </div>
+  );
+}

--- a/frontend/src/LoginForm.test.jsx
+++ b/frontend/src/LoginForm.test.jsx
@@ -180,28 +180,28 @@ describe('LoginForm', () => {
 
       fireEvent.click(screen.getByRole('button', { name: 'Add' }));
       await screen.findByRole('heading', { name: 'Add' });
-      expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
-      fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+      expect(screen.getAllByRole('button', { name: 'Back' })).toHaveLength(2);
+      fireEvent.click(screen.getAllByRole('button', { name: 'Back' })[0]);
       await screen.findByRole('button', { name: 'Compare' });
       fireEvent.click(screen.getByRole('button', { name: 'Compare' }));
       await screen.findByRole('heading', { name: 'Compare' });
-      fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+      fireEvent.click(screen.getAllByRole('button', { name: 'Back' })[0]);
       await screen.findByRole('button', { name: 'Search' });
       fireEvent.click(screen.getByRole('button', { name: 'Search' }));
       await screen.findByRole('heading', { name: 'Search' });
-      fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+      fireEvent.click(screen.getAllByRole('button', { name: 'Back' })[0]);
       await screen.findByRole('button', { name: 'Ask' });
       fireEvent.click(screen.getByRole('button', { name: 'Ask' }));
       await screen.findByRole('heading', { name: 'Ask' });
-      fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+      fireEvent.click(screen.getAllByRole('button', { name: 'Back' })[0]);
       await screen.findByRole('button', { name: 'Questions' });
       fireEvent.click(screen.getByRole('button', { name: 'Questions' }));
       await screen.findByRole('heading', { name: 'Questions' });
-      fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+      fireEvent.click(screen.getAllByRole('button', { name: 'Back' })[0]);
       await screen.findByRole('button', { name: 'Friends' });
       fireEvent.click(screen.getByRole('button', { name: 'Friends' }));
       await screen.findByRole('heading', { name: 'Friends' });
-      fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+      fireEvent.click(screen.getAllByRole('button', { name: 'Back' })[0]);
     }
   );
 });

--- a/frontend/src/Questions.jsx
+++ b/frontend/src/Questions.jsx
@@ -30,6 +30,11 @@ export default function Questions({ onBack = () => {} }) {
           </li>
         ))}
       </ul>
+      <footer className="view-footer">
+        <button type="button" className="back-button" onClick={onBack}>
+          Back
+        </button>
+      </footer>
     </div>
   );
 }

--- a/frontend/src/Questions.test.jsx
+++ b/frontend/src/Questions.test.jsx
@@ -8,7 +8,7 @@ describe('Questions view', () => {
     expect(
       screen.getByRole('heading', { name: 'Questions' })
     ).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Back' })).toHaveLength(2);
   });
 
   it('renders truncated questions list', () => {

--- a/frontend/src/Search.jsx
+++ b/frontend/src/Search.jsx
@@ -1,10 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import { FaBarcode } from 'react-icons/fa';
 import { BACKEND_URL, AUTH_EMAIL, AUTH_PASSWORD } from './config.js';
+import ItemDetails from './ItemDetails.jsx';
 
 export default function Search({ onBack = () => {} }) {
   const [itemIds, setItemIds] = useState([]);
   const [details, setDetails] = useState({});
+  const [selectedId, setSelectedId] = useState(null);
 
   useEffect(() => {
     async function fetchItems() {
@@ -55,6 +57,19 @@ export default function Search({ onBack = () => {} }) {
     };
   }, [itemIds]);
 
+  if (selectedId) {
+    return (
+      <ItemDetails
+        id={selectedId}
+        info={details[selectedId]}
+        onBack={() => setSelectedId(null)}
+        onUpdate={(data) =>
+          setDetails((prev) => ({ ...prev, [selectedId]: data }))
+        }
+      />
+    );
+  }
+
   return (
     <div>
       <div className="view-header">
@@ -71,12 +86,23 @@ export default function Search({ onBack = () => {} }) {
             info && info.description && info.description.barcode;
           return (
             <li key={id}>
-              {name}
+              <button
+                type="button"
+                className="item-button"
+                onClick={() => setSelectedId(id)}
+              >
+                {name}
+              </button>
               {hasBarcode && <FaBarcode aria-label="barcode" />}
             </li>
           );
         })}
       </ul>
+      <footer className="view-footer">
+        <button type="button" className="back-button" onClick={onBack}>
+          Back
+        </button>
+      </footer>
     </div>
   );
 }

--- a/frontend/src/Search.test.jsx
+++ b/frontend/src/Search.test.jsx
@@ -8,7 +8,7 @@ describe('Search view', () => {
   it('shows Search title', () => {
     render(<Search />);
     expect(screen.getByRole('heading', { name: 'Search' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Back' })).toHaveLength(2);
   });
 
   it('loads item IDs on mount', async () => {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -154,3 +154,21 @@ body.desktop .ask-form {
   max-width: 600px;
 }
 
+/* footer back button */
+.view-footer {
+  padding: 1rem;
+  display: flex;
+  justify-content: center;
+}
+
+.view-footer .back-button {
+  width: 100%;
+}
+
+@media (min-width: 601px) {
+  .view-footer .back-button {
+    width: auto;
+    min-width: 200px;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add ItemDetails component for single items
- let Search show ItemDetails and keep data cached
- add footer with Back button to every view
- style footer button for mobile/desktop
- adjust tests for extra Back button

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851d3708a68832788bb727e7f162aa4