### PR TITLE
Fix password input width

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -116,11 +116,15 @@ body.desktop .login-form {
 .password-container {
   display: flex;
   align-items: center;
+  width: 100%;
 }
 
 /* make password field fill space and icon small at the end */
 .password-container input {
   flex: 1;
+  width: 100%;
+  box-sizing: border-box;
+  min-width: 0;
 }
 
 .password-toggle {


### PR DESCRIPTION
## Summary
- ensure `.password-container` uses full width
- ensure password input expands within its container

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851d4e9b32c832792f7c77e6aec2fb2