### PR TITLE
Add automatic login on page load

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -32,6 +32,7 @@ Change the backend API address in `src/config.js` if your server runs on a diffe
 ### Login Cookies
 The login form has a **Remember me** option. When checked, the app stores your
 email and password in browser cookies so the inputs are pre-filled next time.
+When both cookies exist, the form submits automatically on load.
 
 ### Barcode Scanning
 This app ships with a custom React hook `useBarcodeScanner`. It uses the `@zxing/browser` library to read barcodes from the camera. The hook is not used yet but you can import it and render a `video` element with the provided `ref` when you want to scan codes.

--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -28,6 +28,7 @@ export default function LoginForm({ onLogin }) {
   const [message, setMessage] = useState('');
   const [showSignup, setShowSignup] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
+  const [autoLogin, setAutoLogin] = useState(false);
   const userInfo = useSelector((state) => state.user.userInfo);
   const currentView = useSelector((state) => state.user.currentView);
   const dispatch = useDispatch();
@@ -42,7 +43,17 @@ export default function LoginForm({ onLogin }) {
     if (matchPassword) {
       setPassword(decodeURIComponent(matchPassword[1]));
     }
+    if (matchEmail && matchPassword) {
+      setAutoLogin(true);
+    }
   }, []);
+
+  useEffect(() => {
+    if (autoLogin && email && password) {
+      handleSubmit({ preventDefault: () => {} });
+      setAutoLogin(false);
+    }
+  }, [autoLogin, email, password]);
 
   async function handleSubmit(e) {
     e.preventDefault();

--- a/frontend/src/LoginForm.test.jsx
+++ b/frontend/src/LoginForm.test.jsx
@@ -12,7 +12,16 @@ function renderWithProvider(ui) {
 }
 
 describe('LoginForm', () => {
-  afterEach(() => vi.restoreAllMocks());
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.cookie
+      .split(';')
+      .forEach(
+        (c) =>
+          (document.cookie = c
+            .replace(/=.*/, '=;expires=' + new Date(0).toUTCString() + ';path=/'))
+      );
+  });
   it('renders email and password inputs', () => {
     renderWithProvider(<LoginForm />);
     expect(screen.getByTestId('email-input')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- auto-submit login form when cookies contain saved credentials
- update `LoginForm.test.jsx` to clear cookies after each test
- document auto login in frontend README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851d3a8c010832799070c6a8517f5d3