### PR TITLE
Add OpenAI smoothing endpoint

### DIFF
--- a/server/src/main/java/com/memoritta/server/config/OpenAiConfig.java
+++ b/server/src/main/java/com/memoritta/server/config/OpenAiConfig.java
@@ -1,0 +1,17 @@
+package com.memoritta.server.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Getter
+@Setter
+public class OpenAiConfig {
+    @Value("${openai.url:https://api.openai.com/v1/chat/completions}")
+    private String url;
+
+    @Value("${openai.api-key:changeme}")
+    private String apiKey;
+}

--- a/server/src/main/java/com/memoritta/server/controller/AiController.java
+++ b/server/src/main/java/com/memoritta/server/controller/AiController.java
@@ -1,0 +1,26 @@
+package com.memoritta.server.controller;
+
+import com.memoritta.server.manager.OpenAiManager;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/ai")
+public class AiController {
+
+    private final OpenAiManager openAiManager;
+
+    @PostMapping("/smooth")
+    @Operation(
+            summary = "Smooth text",
+            description = "Uses OpenAI to smooth and check spelling of provided text"
+    )
+    public String smooth(@RequestBody String text) {
+        return openAiManager.smoothText(text);
+    }
+}

--- a/server/src/main/java/com/memoritta/server/manager/OpenAiManager.java
+++ b/server/src/main/java/com/memoritta/server/manager/OpenAiManager.java
@@ -1,0 +1,56 @@
+package com.memoritta.server.manager;
+
+import com.memoritta.server.config.OpenAiConfig;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@AllArgsConstructor
+public class OpenAiManager {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final OpenAiConfig config;
+
+    public String smoothText(String text) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(config.getApiKey());
+
+        Map<String, Object> message = Map.of(
+                "role", "user",
+                "content", "Please smooth and check spelling of this text. Keep the original language. Text: " + text
+        );
+        Map<String, Object> body = Map.of(
+                "model", "gpt-3.5-turbo",
+                "messages", List.of(message)
+        );
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(body, headers);
+        Map<?, ?> response = restTemplate.postForObject(config.getUrl(), entity, Map.class);
+        if (response == null) {
+            return text;
+        }
+        List<?> choices = (List<?>) response.get("choices");
+        if (choices == null || choices.isEmpty()) {
+            return text;
+        }
+        Object choice = choices.get(0);
+        if (choice instanceof Map<?,?> choiceMap) {
+            Object msg = choiceMap.get("message");
+            if (msg instanceof Map<?,?> msgMap) {
+                Object content = msgMap.get("content");
+                if (content != null) {
+                    return content.toString().trim();
+                }
+            }
+        }
+        return text;
+    }
+}

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -41,3 +41,6 @@ management:
   endpoint:
     health:
       show-details: always
+openai:
+  url: "https://api.openai.com/v1/chat/completions"
+  api-key: ""

--- a/server/src/test/java/com/memoritta/server/controller/AiControllerTest.java
+++ b/server/src/test/java/com/memoritta/server/controller/AiControllerTest.java
@@ -1,0 +1,47 @@
+package com.memoritta.server.controller;
+
+import com.memoritta.server.manager.OpenAiManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@ContextConfiguration(classes = {AiControllerTest.Config.class, AiController.class})
+class AiControllerTest {
+
+    @Configuration
+    static class Config {
+        @Bean
+        OpenAiManager openAiManager() {
+            return mock(OpenAiManager.class);
+        }
+    }
+
+    @Autowired
+    private OpenAiManager openAiManager;
+
+    @Autowired
+    private AiController aiController;
+
+    @BeforeEach
+    void resetMock() {
+        reset(openAiManager);
+    }
+
+    @Test
+    void smooth_shouldReturnResponse() {
+        when(openAiManager.smoothText(anyString())).thenReturn("done");
+
+        String result = aiController.smooth("test");
+
+        assertThat(result).isEqualTo("done");
+    }
+}


### PR DESCRIPTION
## Summary
- configure OpenAI settings
- implement OpenAI manager to call GPT
- expose `/ai/smooth` endpoint
- test controller behaviour

## Testing
- `mvn -q test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6851dd3034348327b1adf555f05be642