### PR TITLE
Add JaCoCo coverage plugin

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -161,6 +161,26 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- JaCoCo plugin to generate coverage report for unit tests -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.13</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
## Summary
- enable JaCoCo in the server module to generate unit test coverage

## Testing
- `scripts/setup-maven.sh`
- `mvn -pl server test` *(fails: Non-resolvable parent POM – Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6851e0ce4bb48327bd1fd941cea69949