### PR TITLE
Add logout button to Welcome footer

### DIFF
--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -213,11 +213,15 @@ export default function LoginForm({ onLogin }) {
                   <MdGroup /> Friends
                 </button>
               </div>
-              <div>
-                <button type="button" onClick={handleLogout}>
+              <footer className="view-footer">
+                <button
+                  type="button"
+                  className="back-button"
+                  onClick={handleLogout}
+                >
                   Logout
                 </button>
-              </div>
+              </footer>
             </>
           )}
           {currentView === 'add' && (


### PR DESCRIPTION
## Summary
- move logout action into a footer on the main "Welcome" screen
- keep other views unchanged

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851e612eab483279b3d0555d29f44b7