### PR TITLE
Load item pictures from backend

### DIFF
--- a/frontend/src/ItemDetails.test.jsx
+++ b/frontend/src/ItemDetails.test.jsx
@@ -7,30 +7,60 @@ import { BACKEND_URL, AUTH_EMAIL, AUTH_PASSWORD } from './config.js';
 describe('ItemDetails', () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it('shows provided info without fetching', () => {
+  it('shows provided info and loads picture', async () => {
     const info = {
       name: 'Beer',
-      description: { barcode: '123', note: 'note', pictures: [{ picture: 'img' }] },
+      description: { barcode: '123', note: 'note', pictures: [{ id: 'img1' }] },
     };
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        arrayBuffer: () => Promise.resolve(new Uint8Array([1]).buffer),
+      })
+    );
     render(<ItemDetails id="1" info={info} />);
+    await screen.findByAltText('Item');
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${BACKEND_URL}/data?id=img1`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: `Basic ${btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`)}`,
+        }),
+      })
+    );
     expect(screen.getByText('Beer')).toBeInTheDocument();
     expect(screen.getByLabelText('barcode')).toBeInTheDocument();
     expect(screen.getByText('note')).toBeInTheDocument();
-    expect(screen.getByAltText('Item')).toBeInTheDocument();
   });
 
   it('fetches info when not provided', async () => {
     const item = {
       name: 'Wine',
-      description: { barcode: '789', pictures: [{ picture: 'img' }] },
+      description: { barcode: '789', pictures: [{ id: 'img2' }] },
     };
-    global.fetch = vi.fn(() =>
-      Promise.resolve({ ok: true, json: () => Promise.resolve(item) })
-    );
+    global.fetch = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(item) })
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          arrayBuffer: () => Promise.resolve(new Uint8Array([2]).buffer),
+        })
+      );
     render(<ItemDetails id="2" />);
-    await screen.findByText('Wine');
+    await screen.findByAltText('Item');
     expect(global.fetch).toHaveBeenCalledWith(
       `${BACKEND_URL}/item?id=2`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: `Basic ${btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`)}`,
+        }),
+      })
+    );
+    expect(global.fetch).toHaveBeenLastCalledWith(
+      `${BACKEND_URL}/data?id=img2`,
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: `Basic ${btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`)}`,

--- a/frontend/src/Search.test.jsx
+++ b/frontend/src/Search.test.jsx
@@ -62,7 +62,7 @@ describe('Search view', () => {
     const ids = ['123'];
     const item = {
       name: 'Beer',
-      description: { barcode: '789', pictures: [{ picture: 'img' }] },
+      description: { barcode: '789', pictures: [{ id: 'pic1' }] },
     };
     global.fetch = vi
       .fn()
@@ -71,13 +71,27 @@ describe('Search view', () => {
       )
       .mockImplementationOnce(() =>
         Promise.resolve({ ok: true, json: () => Promise.resolve(item) })
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          arrayBuffer: () => Promise.resolve(new Uint8Array([3]).buffer),
+        })
       );
     render(<Search />);
     const itemEl = await screen.findByText('Beer');
     global.fetch.mockClear();
     fireEvent.click(itemEl);
-    await screen.findByRole('heading', { name: 'Item details' });
-    expect(global.fetch).not.toHaveBeenCalled();
+    await screen.findByAltText('Item');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${BACKEND_URL}/data?id=pic1`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: `Basic ${btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`)}`,
+        }),
+      })
+    );
     expect(screen.getByText('789')).toBeInTheDocument();
   });
 });

--- a/server/src/main/java/com/memoritta/server/controller/DataController.java
+++ b/server/src/main/java/com/memoritta/server/controller/DataController.java
@@ -1,0 +1,35 @@
+package com.memoritta.server.controller;
+
+import com.memoritta.server.manager.BinaryDataManager;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.AllArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@AllArgsConstructor
+public class DataController {
+
+    private final BinaryDataManager binaryDataManager;
+
+    @GetMapping("/data")
+    @Operation(summary = "Load binary data", description = "Loads binary data by ID")
+    public ResponseEntity<byte[]> loadData(
+            @RequestParam
+            @Parameter(description = "UUID of the data") String id) {
+        byte[] data = binaryDataManager.load(UUID.fromString(id));
+        if (data == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok()
+                .header("X-Data-Type", "picture")
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .body(data);
+    }
+}


### PR DESCRIPTION
## Summary
- add new `/data` backend endpoint to load binary data
- fetch images from `/data` in Item details
- update tests for new picture loading logic

## Testing
- `npm install`
- `npm test`
- `mvn test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6851e77b6c088327b539a6cfc4083f2f