### PR TITLE
Add question list loading and detail view

### DIFF
--- a/frontend/src/QuestionDetails.jsx
+++ b/frontend/src/QuestionDetails.jsx
@@ -1,0 +1,73 @@
+import React, { useState, useEffect } from 'react';
+import { BACKEND_URL, AUTH_EMAIL, AUTH_PASSWORD } from './config.js';
+
+export default function QuestionDetails({ id, onBack = () => {} }) {
+  const [question, setQuestion] = useState(null);
+  const [answers, setAnswers] = useState([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const token = btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`);
+        const resp = await fetch(`${BACKEND_URL}/question/detail?id=${id}`, {
+          headers: { Authorization: `Basic ${token}` },
+        });
+        if (!cancelled && resp.ok) {
+          const data = await resp.json();
+          setQuestion(data);
+        }
+      } catch (err) {
+        // ignore
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const token = btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`);
+        const resp = await fetch(`${BACKEND_URL}/answer?questionId=${id}`, {
+          headers: { Authorization: `Basic ${token}` },
+        });
+        if (!cancelled && resp.ok) {
+          const data = await resp.json();
+          setAnswers(data);
+        }
+      } catch (err) {
+        // ignore
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  return (
+    <div>
+      <div className="view-header">
+        <h1>Question details</h1>
+        <button type="button" className="back-button" onClick={onBack}>
+          Back
+        </button>
+      </div>
+      {question && <p>{question.question}</p>}
+      <ul>
+        {answers.map((a) => (
+          <li key={a.id}>{a.text}</li>
+        ))}
+      </ul>
+      <footer className="view-footer">
+        <button type="button" className="back-button" onClick={onBack}>
+          Back
+        </button>
+      </footer>
+    </div>
+  );
+}

--- a/frontend/src/Questions.test.jsx
+++ b/frontend/src/Questions.test.jsx
@@ -1,37 +1,78 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import { Provider } from 'react-redux';
+import { createAppStore } from './store.js';
+import { BACKEND_URL, AUTH_EMAIL, AUTH_PASSWORD } from './config.js';
 import Questions from './Questions.jsx';
 
+function renderWithStore(ui) {
+  const store = createAppStore({
+    user: { userInfo: { id: 'u1' }, currentView: null },
+  });
+  return render(<Provider store={store}>{ui}</Provider>);
+}
+
 describe('Questions view', () => {
+  afterEach(() => vi.restoreAllMocks());
+
   it('shows Questions title', () => {
-    render(<Questions />);
+    renderWithStore(<Questions />);
     expect(
       screen.getByRole('heading', { name: 'Questions' })
     ).toBeInTheDocument();
     expect(screen.getAllByRole('button', { name: 'Back' })).toHaveLength(2);
   });
 
-  it('renders truncated questions list', () => {
-    window.innerWidth = 80;
-    render(<Questions />);
-    const items = screen.getAllByRole('listitem');
-    expect(items).toHaveLength(3);
-    expect(items.some((li) => li.textContent.endsWith('...'))).toBe(true);
+  it('loads questions on mount', async () => {
+    const qs = [
+      { id: 'q1', description: 'short' },
+      { id: 'q2', description: 'a'.repeat(140) },
+    ];
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(qs) })
+    );
+    renderWithStore(<Questions />);
+    await screen.findByText('short');
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${BACKEND_URL}/question?userId=u1`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: `Basic ${btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`)}`,
+        }),
+      })
+    );
+    expect(screen.getByText('short')).toBeInTheDocument();
+    expect(screen.getByText(`${'a'.repeat(125)}...`)).toBeInTheDocument();
   });
 
-  it('renders truncated questions list', () => {
-    window.innerWidth = 80;
-    render(<Questions />);
-    const items = screen.getAllByRole('listitem');
-    expect(items).toHaveLength(3);
-    expect(items.some((li) => li.textContent.endsWith('...'))).toBe(true);
-  });
-
-  it('renders truncated questions list', () => {
-    window.innerWidth = 80;
-    render(<Questions />);
-    const items = screen.getAllByRole('listitem');
-    expect(items).toHaveLength(3);
-    expect(items.some((li) => li.textContent.endsWith('...'))).toBe(true);
+  it('opens details view on click', async () => {
+    const qs = [{ id: 'q1', description: 'short' }];
+    global.fetch = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(qs) })
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ question: 'q' }),
+        })
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+      );
+    renderWithStore(<Questions />);
+    const item = await screen.findByText('short');
+    fireEvent.click(item);
+    await screen.findByRole('heading', { name: 'Question details' });
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${BACKEND_URL}/question/detail?id=q1`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: `Basic ${btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`)}`,
+        }),
+      })
+    );
   });
 });


### PR DESCRIPTION
## Summary
- download question list from backend in Questions view
- add QuestionDetails view with answers
- test questions fetching and navigation

## Testing
- `npm --prefix frontend test`

------
https://chatgpt.com/codex/tasks/task_e_6851e9cd5d9c8327b64cb7e851ce638a