### PR TITLE
Add Smooth text feature

### DIFF
--- a/frontend/src/Ask.test.jsx
+++ b/frontend/src/Ask.test.jsx
@@ -42,4 +42,28 @@ describe('Ask view', () => {
       expect(screen.getByRole('button', { name: 'Update' })).toBeInTheDocument();
     });
   });
+
+  it('smooths text and applies result', async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ ok: true, text: () => Promise.resolve('fixed') })
+    );
+    renderWithStore(<Ask />);
+    fireEvent.change(screen.getByTestId('ask-textarea'), {
+      target: { value: 'orig' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Smooth' }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${BACKEND_URL}/ai/smooth`,
+        expect.objectContaining({ method: 'POST' })
+      );
+      expect(screen.getByTestId('smooth-popup')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Apply' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+    expect(screen.queryByTestId('smooth-popup')).not.toBeInTheDocument();
+    expect(screen.getByTestId('ask-textarea').value).toBe('fixed');
+  });
 });

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -183,3 +183,31 @@ body.desktop .ask-form {
     min-width: 200px;
   }
 }
+
+/* smooth popup */
+.popup-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.popup-window {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.popup-buttons {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}


### PR DESCRIPTION
## Summary
- add Smooth button in Ask view to call `/ai/smooth`
- show smoothed text in popup with Apply/Cancel
- disable Smooth button temporarily to avoid spamming
- style popup overlay and window
- test smoothing behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851ecbe14748327a5654b0b7a7704d1