### PR TITLE
feat(frontend): include photo when posting item

### DIFF
--- a/frontend/src/AddView.jsx
+++ b/frontend/src/AddView.jsx
@@ -144,6 +144,9 @@ export default function AddView({ onBack = () => {} }) {
     if (barcode) {
       formData.append('barCode', barcode);
     }
+    if (photo) {
+      formData.append('pictureBase64', photo.split(',')[1]);
+    }
     try {
       const token = btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`);
       await fetch(`${BACKEND_URL}/item`, {


### PR DESCRIPTION
## Summary
- allow Add view to send captured photo in POST request
- test adding item with a photo

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851edf288c48327b6a585af9329b8de