### PR TITLE
Add retry logic in restart workflows

### DIFF
--- a/.github/workflows/deploy-on-merge.yml
+++ b/.github/workflows/deploy-on-merge.yml
@@ -24,4 +24,23 @@ jobs:
           FRONTEND_HOME: ${{ vars.FRONTEND_HOME }}
           SERVER_SCRIPT: ${{ vars.SERVER_SCRIPT }}
           FRONTEND_SCRIPT: ${{ vars.FRONTEND_SCRIPT }}
-        run: ./scripts/restart-services.sh
+        run: |
+          set -e
+          for attempt in 1 2 3; do
+            output=$(./scripts/restart-services.sh 2>&1)
+            status=$?
+            echo "$output"
+            if [ $status -ne 0 ]; then
+              exit $status
+            fi
+            if ! echo "$output" | grep -q "Another restart is in progress. Exiting."; then
+              exit 0
+            fi
+            if [ $attempt -eq 3 ]; then
+              echo "give up"
+              exit 0
+            fi
+            sleep_time=$((RANDOM % 16 + 15))
+            echo "Another restart in progress. Wait ${sleep_time}s before retry #$((attempt+1))"
+            sleep "$sleep_time"
+          done

--- a/.github/workflows/restart-services.yml
+++ b/.github/workflows/restart-services.yml
@@ -21,4 +21,23 @@ jobs:
           FRONTEND_HOME: ${{ vars.FRONTEND_HOME }}
           SERVER_SCRIPT: ${{ vars.SERVER_SCRIPT }}
           FRONTEND_SCRIPT: ${{ vars.FRONTEND_SCRIPT }}
-        run: ./scripts/restart-services.sh
+        run: |
+          set -e
+          for attempt in 1 2 3; do
+            output=$(./scripts/restart-services.sh 2>&1)
+            status=$?
+            echo "$output"
+            if [ $status -ne 0 ]; then
+              exit $status
+            fi
+            if ! echo "$output" | grep -q "Another restart is in progress. Exiting."; then
+              exit 0
+            fi
+            if [ $attempt -eq 3 ]; then
+              echo "give up"
+              exit 0
+            fi
+            sleep_time=$((RANDOM % 16 + 15))
+            echo "Another restart in progress. Wait ${sleep_time}s before retry #$((attempt+1))"
+            sleep "$sleep_time"
+          done


### PR DESCRIPTION
## Summary
- retry restarting services up to 3 times
- wait 15-30 seconds between retries
- give up gracefully if all attempts fail

## Testing
- `npm run test --silent`
- `mvn -q test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6851f02697248327be119edbefca4868