### PR TITLE
Update restart script and workflows

### DIFF
--- a/.github/workflows/deploy-on-merge.yml
+++ b/.github/workflows/deploy-on-merge.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           set -e
           for attempt in 1 2 3; do
-            output=$(./scripts/restart-services.sh 2>&1)
+            output=$(ATTEMPT="$attempt" ./scripts/restart-services.sh 2>&1)
             status=$?
             echo "$output"
             if [ $status -ne 0 ]; then
@@ -40,7 +40,7 @@ jobs:
               echo "give up"
               exit 0
             fi
-            sleep_time=$((RANDOM % 16 + 15))
-            echo "Another restart in progress. Wait ${sleep_time}s before retry #$((attempt+1))"
+            sleep_time=$((30 + RANDOM % 21 + 10))
+            echo "Another restart in progress during attempt #$attempt. Wait ${sleep_time}s before retry #$((attempt+1))"
             sleep "$sleep_time"
           done

--- a/.github/workflows/restart-services.yml
+++ b/.github/workflows/restart-services.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           set -e
           for attempt in 1 2 3; do
-            output=$(./scripts/restart-services.sh 2>&1)
+            output=$(ATTEMPT="$attempt" ./scripts/restart-services.sh 2>&1)
             status=$?
             echo "$output"
             if [ $status -ne 0 ]; then
@@ -37,7 +37,7 @@ jobs:
               echo "give up"
               exit 0
             fi
-            sleep_time=$((RANDOM % 16 + 15))
-            echo "Another restart in progress. Wait ${sleep_time}s before retry #$((attempt+1))"
+            sleep_time=$((30 + RANDOM % 21 + 10))
+            echo "Another restart in progress during attempt #$attempt. Wait ${sleep_time}s before retry #$((attempt+1))"
             sleep "$sleep_time"
           done

--- a/README.md
+++ b/README.md
@@ -85,4 +85,4 @@ All workflows expect an environment called `PROD`. To configure it:
 
 `restart-services.yml` reads these values and passes them to `scripts/restart-services.sh` to restart the services on your server whenever `main` is updated.
 The script uses a lock file on the server so only one restart runs at a time.
-If another run holds the lock for more than 30 seconds, the new run exits without changes.
+If another run holds the lock, the script waits up to 30 seconds plus a random 10–30 seconds before giving up.


### PR DESCRIPTION
## Summary
- log attempt number when a restart is skipped
- wait at least 40-60 seconds before giving up on a restart
- document longer wait time in README

## Testing
- `npm test --prefix frontend` *(fails: vitest not found)*
- `mvn -q test -DskipTests=false` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851f2ac5e748327b5242c0560c4de17