### PR TITLE
Improve request parameter error handling

### DIFF
--- a/server/src/main/java/com/memoritta/server/advice/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/memoritta/server/advice/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 
 import java.util.NoSuchElementException;
 
@@ -26,6 +27,13 @@ public class GlobalExceptionHandler {
     public ResponseEntity<String> handleNotFound(NoSuchElementException ex) {
         log.error("NoSuchElementException", ex);
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body("User not found");
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<String> handleMissingParameter(MissingServletRequestParameterException ex) {
+        log.warn("Missing request parameter: {}", ex.getParameterName());
+        String message = "Missing required parameter: " + ex.getParameterName();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(message);
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
## Summary
- handle missing request parameters gracefully

## Testing
- `mvn -q -f server/pom.xml -DskipTests=false test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_6851f55d0bf48327959a7fdd9272c6bd