### PR TITLE
Fix coverage summary division by zero

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -39,7 +39,11 @@ jobs:
           MISSED=$(echo "$LINE" | grep -o 'missed="[0-9]\+' | cut -d'"' -f2)
           COVERED=$(echo "$LINE" | grep -o 'covered="[0-9]\+' | cut -d'"' -f2)
           TOTAL=$((MISSED + COVERED))
-          PCT=$((100 * COVERED / TOTAL))
+          if [ "$TOTAL" -gt 0 ]; then
+            PCT=$((100 * COVERED / TOTAL))
+          else
+            PCT=0
+          fi
           echo "Line coverage: $PCT%" | tee coverage-summary.txt
           echo '## Coverage' >> $GITHUB_STEP_SUMMARY
           echo "Line coverage: $PCT%" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- avoid division by zero when summarizing coverage in GitHub Actions

## Testing
- `mvn -q -pl server -am test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851f62e1624832784bc6c6255d82dd7