### PR TITLE
Extend server controller tests

### DIFF
--- a/server/src/test/java/com/memoritta/server/controller/ServerControllerTest.java
+++ b/server/src/test/java/com/memoritta/server/controller/ServerControllerTest.java
@@ -4,10 +4,12 @@ import com.memoritta.server.config.ServerConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest
@@ -25,5 +27,19 @@ class ServerControllerTest {
 
         // Then
         assertNotNull(result);
+    }
+
+    @Test
+    void getVersion_shouldReturnDefaultVersion() {
+        String version = serverController.getVersion();
+
+        assertEquals("1.0.0", version);
+    }
+
+    @Test
+    void ping_shouldReturnPong() {
+        ResponseEntity<String> response = serverController.ping();
+
+        assertEquals(ResponseEntity.ok("pong"), response);
     }
 }


### PR DESCRIPTION
## Summary
- cover the default server version in `ServerControllerTest`
- check ping GET endpoint in `ServerControllerTest`

## Testing
- `mvn -q -pl server test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851f6863d5483278e4ff40ac085d269