### PR TITLE
Move deployment hook to release branch creation

### DIFF
--- a/.github/workflows/deploy-on-merge.yml
+++ b/.github/workflows/deploy-on-merge.yml
@@ -1,14 +1,13 @@
-name: Deploy to PROD on merge
+name: Deploy to PROD on release branch
 
 on:
-  pull_request:
-    branches: [ main ]
-    types:
-      - closed
+  create:
+    branches:
+      - 'release/**'
 
 jobs:
   deploy:
-    if: ${{ github.event.pull_request.merged == true }}
+    if: ${{ github.ref_type == 'branch' }}
     environment: PROD
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -67,8 +67,10 @@ The project uses GitHub Actions to deploy the backend and frontend.
 Workflows:
 
 - `.github/workflows/deploy-prod.yml` runs after the *Integration Tests* workflow.
-- `.github/workflows/deploy-on-merge.yml` runs when a pull request is merged into `main`.
+- `.github/workflows/deploy-on-merge.yml` runs when a branch named `release/*` is created.
 - `.github/workflows/restart-services.yml` runs whenever code is pushed to `main`.
+
+`deploy-on-merge.yml` starts when you create a `release/*` branch. It checks out the code and runs `scripts/restart-services.sh` to restart the services.
 
 All workflows expect an environment called `PROD`. To configure it:
 


### PR DESCRIPTION
## Summary
- trigger deploy-on-merge workflow when creating a `release/*` branch
- describe new trigger in README

## Testing
- `mvn -q -pl server -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68525d7b47fc8327bba096f6290c102c