### PR TITLE
Add server version display

### DIFF
--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -14,6 +14,7 @@ describe('App login flow', () => {
       Promise.resolve({
         ok: true,
         json: () => Promise.resolve(mockResponse),
+        text: () => Promise.resolve('1.0.0'),
       })
     );
 
@@ -35,6 +36,7 @@ describe('App login flow', () => {
         'nickname1'
       );
       expect(screen.queryByTestId('email-input')).not.toBeInTheDocument();
+      expect(screen.getByText('Server version: 1.0.0')).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -29,6 +29,7 @@ export default function LoginForm({ onLogin }) {
   const [showSignup, setShowSignup] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [autoLogin, setAutoLogin] = useState(false);
+  const [serverVersion, setServerVersion] = useState('');
   const userInfo = useSelector((state) => state.user.userInfo);
   const currentView = useSelector((state) => state.user.currentView);
   const dispatch = useDispatch();
@@ -120,6 +121,23 @@ export default function LoginForm({ onLogin }) {
     dispatch(setCurrentView(null));
   }
 
+  useEffect(() => {
+    async function fetchVersion() {
+      try {
+        const resp = await fetch(`${BACKEND_URL}/version`);
+        if (resp.ok) {
+          const ver = await resp.text();
+          setServerVersion(ver);
+        }
+      } catch {
+        // ignore errors
+      }
+    }
+    if (userInfo) {
+      fetchVersion();
+    }
+  }, [userInfo]);
+
   return (
     <form className="login-form" onSubmit={handleSubmit}>
       {!userInfo && (
@@ -176,6 +194,11 @@ export default function LoginForm({ onLogin }) {
           {currentView === null && (
             <>
               <h1>Welcome</h1>
+              {serverVersion && (
+                <p className="server-version">
+                  Server version: {serverVersion}
+                </p>
+              )}
               <p data-testid="user-nickname">{userInfo.nickname}</p>
               <h2>User Info</h2>
               <ul>

--- a/frontend/src/LoginForm.test.jsx
+++ b/frontend/src/LoginForm.test.jsx
@@ -18,8 +18,10 @@ describe('LoginForm', () => {
       .split(';')
       .forEach(
         (c) =>
-          (document.cookie = c
-            .replace(/=.*/, '=;expires=' + new Date(0).toUTCString() + ';path=/'))
+          (document.cookie = c.replace(
+            /=.*/,
+            '=;expires=' + new Date(0).toUTCString() + ';path=/'
+          ))
       );
   });
   it('renders email and password inputs', () => {
@@ -51,6 +53,7 @@ describe('LoginForm', () => {
       Promise.resolve({
         ok: true,
         json: () => Promise.resolve(mockResponse),
+        text: () => Promise.resolve('1.0.0'),
       })
     );
 
@@ -85,6 +88,7 @@ describe('LoginForm', () => {
       screen.getByRole('button', { name: 'Questions' })
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Friends' })).toBeInTheDocument();
+    expect(screen.getByText('Server version: 1.0.0')).toBeInTheDocument();
   });
 
   it('stores credentials in cookies when remember is checked', async () => {
@@ -96,6 +100,7 @@ describe('LoginForm', () => {
       Promise.resolve({
         ok: true,
         json: () => Promise.resolve(mockResponse),
+        text: () => Promise.resolve('1.0.0'),
       })
     );
 
@@ -139,7 +144,9 @@ describe('LoginForm', () => {
     fireEvent.click(screen.getByRole('button', { name: /login/i }));
 
     await screen.findByText(/login failed/i);
-    const signupButton = screen.getByRole('button', { name: /create account/i });
+    const signupButton = screen.getByRole('button', {
+      name: /create account/i,
+    });
     expect(signupButton).toBeInTheDocument();
 
     fireEvent.click(signupButton);
@@ -171,6 +178,12 @@ describe('LoginForm', () => {
           return Promise.resolve({
             ok: true,
             json: () => Promise.resolve(mockResponse),
+          });
+        }
+        if (url.endsWith('/version')) {
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve('1.0.0'),
           });
         }
         return Promise.resolve({ ok: false });
@@ -220,7 +233,11 @@ describe('LoginForm', () => {
       jwtToken: 'token',
     };
     global.fetch = vi.fn(() =>
-      Promise.resolve({ ok: true, json: () => Promise.resolve(mockResponse) })
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+        text: () => Promise.resolve('1.0.0'),
+      })
     );
 
     document.cookie = 'email=foo%40example.com';

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -9,6 +9,12 @@ h1 {
   text-align: center;
 }
 
+.server-version {
+  font-size: 0.75rem;
+  text-align: center;
+  margin: 0;
+}
+
 .login-form {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- fetch backend version on login
- show backend version on welcome view
- style server version text
- update tests for new fetch behavior

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685266de7d38832780323db8d7a9c0c8