### PR TITLE
Remove integration tests from build-test job

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -50,28 +50,4 @@ jobs:
 
       - name: Build server
         run: mvn -B -pl server -am package
-
-      - name: Start server
-        run: |
-          java -jar server/target/server-1.0-SNAPSHOT.jar &
-          echo $! > server.pid
-
-      - name: Wait for server
-        run: |
-          for i in {1..30}; do
-            if curl -s http://localhost:9090/actuator/health >/dev/null; then
-              echo "Server is up"
-              exit 0
-            fi
-            sleep 5
-          done
-          echo "Server failed to start" && cat server.pid && exit 1
-
-      - name: Run integration tests
-        run: mvn -B -pl server -Dtest=*IT test
-
-      - name: Stop server
-        if: always()
-        run: |
-          kill $(cat server.pid) || true
           


### PR DESCRIPTION
## Summary
- run integration tests only in e2e-tests job
- simplify build-test job

## Testing
- `mvn -B -pl server -am test` *(fails: could not download dependencies)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685267f634308327a38e7e0ed634e11e