### PR TITLE
Add release automation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,12 @@ All workflows expect an environment called `PROD`. To configure it:
 `restart-services.yml` reads these values and passes them to `scripts/restart-services.sh` to restart the services on your server whenever `main` is updated.
 The script uses a lock file on the server so only one restart runs at a time.
 If another run holds the lock, the script waits up to 30 seconds plus a random 10–30 seconds before giving up.
+
+## Automating Releases
+
+Run `scripts/release.sh` to tag a new version and create a GitHub release.
+The script collects commit messages since the last tag, bumps the version
+according to commit type, pushes the tag, and (if `gh` is installed) creates
+a release with the changelog.
+
+Make the script executable once with `chmod +x scripts/release.sh`.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Automate changelog generation, version bump, git tag and GitHub release.
+
+set -euo pipefail
+
+# Find the last git tag. If none, start from zero.
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+if [ -z "$LAST_TAG" ]; then
+  RANGE=""
+  BASE_VERSION="0.0.0"
+else
+  RANGE="$LAST_TAG..HEAD"
+  BASE_VERSION="${LAST_TAG#v}"
+fi
+
+# Collect commit messages since the last tag.
+CHANGELOG=$(git log $RANGE --pretty=format:"- %s (%h)" )
+
+# Write changelog to file
+NOTES_FILE="release-notes.tmp"
+echo "$CHANGELOG" > "$NOTES_FILE"
+
+# Determine version bump type
+MAJOR=0; MINOR=0; PATCH=0
+IFS='.' read MAJOR MINOR PATCH <<< "$BASE_VERSION"
+
+BUMP="patch"
+if echo "$CHANGELOG" | grep -qiE 'BREAKING'; then
+  BUMP="major"
+elif echo "$CHANGELOG" | grep -qiE '^- feat'; then
+  BUMP="minor"
+fi
+
+case $BUMP in
+  major)
+    MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0;;
+  minor)
+    MINOR=$((MINOR + 1)); PATCH=0;;
+  patch)
+    PATCH=$((PATCH + 1));;
+esac
+
+NEW_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+
+# Create git tag
+git tag -a "$NEW_VERSION" -F "$NOTES_FILE"
+
+# Push tag
+if git remote | grep -q origin; then
+  git push origin "$NEW_VERSION"
+fi
+
+# Create GitHub release if gh CLI is available
+if command -v gh >/dev/null 2>&1; then
+  gh release create "$NEW_VERSION" --notes-file "$NOTES_FILE"
+fi
+
+# Show summary
+cat <<EOF_SUMMARY
+Created $NEW_VERSION with the following notes:
+$CHANGELOG
+EOF_SUMMARY
+
+
+


### PR DESCRIPTION
## Summary
- add `scripts/release.sh` to automate changelog, version bump, tagging and GitHub release
- document the script in README

## Testing
- `bash scripts/setup-maven.sh` *(fails: Network is unreachable)*
- `mvn -q test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_685261fe074c83279afe1bacdc3f66d2