### PR TITLE
Fix auth for /ai/smooth call

### DIFF
--- a/frontend/src/Ask.jsx
+++ b/frontend/src/Ask.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
-import { BACKEND_URL } from './config.js';
+
+import { backendFetch } from './backend.js';
 
 export default function Ask({ onBack = () => {} }) {
   const [question, setQuestion] = useState('');
@@ -18,7 +19,7 @@ export default function Ask({ onBack = () => {} }) {
         fromUserId: userInfo.id,
         question,
       });
-      const resp = await fetch(`${BACKEND_URL}/question`, {
+      const resp = await backendFetch('/question', {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: params,
@@ -38,7 +39,7 @@ export default function Ask({ onBack = () => {} }) {
     setMessage('');
     try {
       const params = new URLSearchParams({ id: questionId, question });
-      const resp = await fetch(`${BACKEND_URL}/question`, {
+      const resp = await backendFetch('/question', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: params,
@@ -59,7 +60,7 @@ export default function Ask({ onBack = () => {} }) {
     setSmoothDisabled(true);
     setTimeout(() => setSmoothDisabled(false), 5000);
     try {
-      const resp = await fetch(`${BACKEND_URL}/ai/smooth`, {
+      const resp = await backendFetch('/ai/smooth', {
         method: 'POST',
         headers: { 'Content-Type': 'text/plain' },
         body: question,

--- a/frontend/src/Ask.test.jsx
+++ b/frontend/src/Ask.test.jsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import { Provider } from 'react-redux';
 import { createAppStore } from './store.js';
-import { BACKEND_URL } from './config.js';
+import { BACKEND_URL, AUTH_EMAIL, AUTH_PASSWORD } from './config.js';
 import Ask from './Ask.jsx';
 
 function renderWithStore(ui) {
@@ -56,7 +56,12 @@ describe('Ask view', () => {
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(
         `${BACKEND_URL}/ai/smooth`,
-        expect.objectContaining({ method: 'POST' })
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            Authorization: `Basic ${btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`)}`,
+          }),
+        })
       );
       expect(screen.getByTestId('smooth-popup')).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Apply' })).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- add authentication details when smoothing text
- check Authorization header in Ask view tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68528fb595a483278eb4fe33688f36c1