### PR TITLE
Enable OpenAI organization and project headers

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -77,3 +77,18 @@ frontend origin (`http://localhost:5174`). Make sure your `WebConfig` and `CorsF
 `@Profile("DEV")` so that CORS is only enabled in development.
 
 Now, your frontend running on a different host or port can access the backend endpoints without CORS errors.
+
+
+## OpenAI Configuration
+
+The application can call OpenAI for text smoothing. Set the following properties in `application.yml` or as environment variables:
+
+```yaml
+openai:
+  url: https://api.openai.com/v1/chat/completions
+  api-key: YOUR_API_KEY
+  organization: org-n9AnfI7a4lvpGr50hbypFLxB
+  project: proj_5ODKT8ABkqMtUdXihb10kbIX
+```
+
+The `organization` and `project` values are optional. If provided, they are sent as `OpenAI-Organization` and `OpenAI-Project` headers.

--- a/server/src/main/java/com/memoritta/server/config/OpenAiConfig.java
+++ b/server/src/main/java/com/memoritta/server/config/OpenAiConfig.java
@@ -14,4 +14,10 @@ public class OpenAiConfig {
 
     @Value("${openai.api-key:changeme}")
     private String apiKey;
+
+    @Value("${openai.organization:}")
+    private String organization;
+
+    @Value("${openai.project:}")
+    private String project;
 }

--- a/server/src/main/java/com/memoritta/server/manager/OpenAiManager.java
+++ b/server/src/main/java/com/memoritta/server/manager/OpenAiManager.java
@@ -23,6 +23,12 @@ public class OpenAiManager {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.setBearerAuth(config.getApiKey());
+        if (config.getOrganization() != null && !config.getOrganization().isBlank()) {
+            headers.add("OpenAI-Organization", config.getOrganization());
+        }
+        if (config.getProject() != null && !config.getProject().isBlank()) {
+            headers.add("OpenAI-Project", config.getProject());
+        }
 
         Map<String, Object> message = Map.of(
                 "role", "user",

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -44,3 +44,5 @@ management:
 openai:
   url: "https://api.openai.com/v1/chat/completions"
   api-key: ""
+  organization: ""
+  project: ""


### PR DESCRIPTION
## Summary
- add organization and project fields to `OpenAiConfig`
- send `OpenAI-Organization` and `OpenAI-Project` headers from `OpenAiManager`
- extend `application.yml` with new settings
- document OpenAI configuration in `server/README.md`

## Testing
- `mvn -q -pl server test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685298d1ebb0832783c51ed3532adf5f