### PR TITLE
Load questions sequentially

### DIFF
--- a/frontend/src/Questions.test.jsx
+++ b/frontend/src/Questions.test.jsx
@@ -25,17 +25,24 @@ describe('Questions view', () => {
   });
 
   it('loads questions on mount', async () => {
-    const qs = [
-      { id: 'q1', description: 'short' },
-      { id: 'q2', description: 'a'.repeat(140) },
-    ];
-    global.fetch = vi.fn(() =>
-      Promise.resolve({ ok: true, json: () => Promise.resolve(qs) })
-    );
+    const ids = ['q1', 'q2'];
+    const q1 = { question: 'short' };
+    const q2 = { question: 'a'.repeat(140) };
+    global.fetch = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(ids) })
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(q1) })
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(q2) })
+      );
     renderWithStore(<Questions />);
     await screen.findByText('short');
     expect(global.fetch).toHaveBeenCalledWith(
-      `${BACKEND_URL}/question?userId=u1`,
+      `${BACKEND_URL}/question/ids?userId=u1`,
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: `Basic ${btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`)}`,
@@ -47,17 +54,17 @@ describe('Questions view', () => {
   });
 
   it('opens details view on click', async () => {
-    const qs = [{ id: 'q1', description: 'short' }];
+    const ids = ['q1'];
     global.fetch = vi
       .fn()
       .mockImplementationOnce(() =>
-        Promise.resolve({ ok: true, json: () => Promise.resolve(qs) })
+        Promise.resolve({ ok: true, json: () => Promise.resolve(ids) })
       )
       .mockImplementationOnce(() =>
-        Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({ question: 'q' }),
-        })
+        Promise.resolve({ ok: true, json: () => Promise.resolve({ question: 'short' }) })
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve({ question: 'q' }) })
       )
       .mockImplementationOnce(() =>
         Promise.resolve({ ok: true, json: () => Promise.resolve([]) })

--- a/server/src/main/java/com/memoritta/server/controller/QuestionController.java
+++ b/server/src/main/java/com/memoritta/server/controller/QuestionController.java
@@ -40,6 +40,14 @@ public class QuestionController {
         return questionManager.listQuestionsForUser(UUID.fromString(userId));
     }
 
+    @GetMapping("/ids")
+    @Operation(summary = "List question IDs", description = "Lists question IDs for the given user")
+    public List<UUID> listQuestionIds(
+            @RequestParam @Parameter(description = "ID of user to get questions for") String userId
+    ) {
+        return questionManager.listQuestionIdsForUser(UUID.fromString(userId));
+    }
+
     @GetMapping("/detail")
     @Operation(summary = "Get question", description = "Fetch single question with answers")
     public Question fetchQuestion(

--- a/server/src/main/java/com/memoritta/server/manager/QuestionManager.java
+++ b/server/src/main/java/com/memoritta/server/manager/QuestionManager.java
@@ -50,6 +50,13 @@ public class QuestionManager {
                 .toList();
     }
 
+    public List<UUID> listQuestionIdsForUser(UUID userId) {
+        return questionRepository.findAll().stream()
+                .filter(dao -> dao.getAudience() != QuestionAudience.DIRECT || userId.equals(dao.getToUserId()))
+                .map(QuestionDao::getId)
+                .toList();
+    }
+
     private QuestionRef toQuestionRef(QuestionDao dao) {
         String desc = dao.getQuestion();
         if (desc != null && desc.length() > descriptionMaxLength) {

--- a/server/src/test/java/com/memoritta/server/controller/QuestionControllerTest.java
+++ b/server/src/test/java/com/memoritta/server/controller/QuestionControllerTest.java
@@ -83,6 +83,25 @@ class QuestionControllerTest {
     }
 
     @Test
+    void listQuestionIds_shouldReturnFiltered() {
+        UUID userId = UUID.randomUUID();
+        QuestionDao direct = QuestionDao.builder()
+                .id(UUID.randomUUID())
+                .toUserId(userId)
+                .audience(QuestionAudience.DIRECT)
+                .build();
+        QuestionDao publicQ = QuestionDao.builder()
+                .id(UUID.randomUUID())
+                .audience(QuestionAudience.EVERYONE)
+                .build();
+        when(questionRepository.findAll()).thenReturn(List.of(direct, publicQ));
+
+        List<UUID> result = questionController.listQuestionIds(userId.toString());
+
+        assertThat(result).containsExactlyInAnyOrder(direct.getId(), publicQ.getId());
+    }
+
+    @Test
     void fetchQuestion_shouldReturnWithAnswers() {
         UUID qid = UUID.randomUUID();
         when(questionRepository.findById(qid))

--- a/server/src/test/java/com/memoritta/server/manager/QuestionManagerTest.java
+++ b/server/src/test/java/com/memoritta/server/manager/QuestionManagerTest.java
@@ -101,6 +101,30 @@ class QuestionManagerTest {
     }
 
     @Test
+    void listQuestionIdsForUser_shouldFilterDirectAudience() {
+        UUID userId = UUID.randomUUID();
+        QuestionDao q1 = QuestionDao.builder()
+                .id(UUID.randomUUID())
+                .toUserId(UUID.randomUUID())
+                .audience(QuestionAudience.DIRECT)
+                .build();
+        QuestionDao q2 = QuestionDao.builder()
+                .id(UUID.randomUUID())
+                .toUserId(userId)
+                .audience(QuestionAudience.DIRECT)
+                .build();
+        QuestionDao q3 = QuestionDao.builder()
+                .id(UUID.randomUUID())
+                .audience(QuestionAudience.EVERYONE)
+                .build();
+        when(questionRepository.findAll()).thenReturn(List.of(q1, q2, q3));
+
+        List<UUID> result = questionManager.listQuestionIdsForUser(userId);
+
+        assertThat(result).containsExactlyInAnyOrder(q2.getId(), q3.getId());
+    }
+
+    @Test
     void updateQuestion_shouldSaveChangedText() {
         UUID id = UUID.randomUUID();
         QuestionDao dao = QuestionDao.builder().id(id).question("old").build();


### PR DESCRIPTION
## Summary
- support listing question ids in backend
- fetch question ids first in Questions view then load details one-by-one
- test the new backend endpoints and frontend behaviour

## Testing
- `mvn -q -f server/pom.xml test` *(fails: unable to download dependencies)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852bfe580a08327801d7a6223f2a790