### PR TITLE
Add full-screen question list

### DIFF
--- a/frontend/src/Questions.jsx
+++ b/frontend/src/Questions.jsx
@@ -66,14 +66,14 @@ export default function Questions({ onBack = () => {} }) {
   }
 
   return (
-    <div>
+    <div className="questions-view">
       <div className="view-header">
         <h1>Questions</h1>
         <button type="button" className="back-button" onClick={onBack}>
           Back
         </button>
       </div>
-      <ul>
+      <ul className="questions-list">
         {questions.map((q) => (
           <li key={q.id} className="question-item">
             <button

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -42,6 +42,21 @@ h1 {
   white-space: nowrap;
 }
 
+.questions-view {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  box-sizing: border-box;
+}
+
+.questions-list {
+  flex: 1;
+  list-style: none;
+  padding: 0 1rem;
+  margin: 0;
+  overflow-y: auto;
+}
+
 .camera-window {
   margin-top: 1rem;
   display: flex;


### PR DESCRIPTION
## Summary
- show loaded questions in a scrollable list
- style Questions view to fill the screen except for header and footer

## Testing
- `npm test --prefix frontend --silent`

------
https://chatgpt.com/codex/tasks/task_e_68532d4dd400832797892d865f4d6f5b