### PR TITLE
Update Search view display

### DIFF
--- a/frontend/src/Search.jsx
+++ b/frontend/src/Search.jsx
@@ -116,8 +116,10 @@ export default function Search({ onBack = () => {} }) {
                 className="item-button"
                 onClick={() => setSelectedId(id)}
               >
-                {name}
-                {hasBarcode && <FaBarcode aria-label="barcode" />}
+                <span className="item-name">{name}</span>
+                {hasBarcode && (
+                  <FaBarcode className="barcode-icon" aria-label="barcode" />
+                )}
               </button>
             </li>
           );

--- a/frontend/src/Search.test.jsx
+++ b/frontend/src/Search.test.jsx
@@ -13,17 +13,17 @@ describe('Search view', () => {
 
   it('loads item IDs on mount', async () => {
     const ids = ['1', '2'];
+    const pending = new Promise(() => {});
     global.fetch = vi
       .fn()
       .mockImplementationOnce(() =>
         Promise.resolve({ ok: true, json: () => Promise.resolve(ids) })
       )
-      .mockImplementation(() =>
-        Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
-      );
+      .mockImplementation(() => pending);
     render(<Search />);
-    const names = await screen.findAllByText('noname');
-    expect(names).toHaveLength(2);
+    for (const id of ids) {
+      expect(await screen.findByText(id)).toBeInTheDocument();
+    }
     expect(global.fetch).toHaveBeenCalledWith(
       `${BACKEND_URL}/items/user`,
       expect.objectContaining({


### PR DESCRIPTION
## Summary
- show UUIDs first in Search view
- keep item name and barcode icon in one line
- update tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68532eb6436c8327a711fe196d931722