### PR TITLE
Add recording button in Ask view

### DIFF
--- a/frontend/src/Ask.jsx
+++ b/frontend/src/Ask.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
+import { FaMicrophone } from 'react-icons/fa';
 
 import { backendFetch } from './backend.js';
 
@@ -10,6 +11,7 @@ export default function Ask({ onBack = () => {} }) {
   const [smoothResult, setSmoothResult] = useState('');
   const [showSmooth, setShowSmooth] = useState(false);
   const [smoothDisabled, setSmoothDisabled] = useState(false);
+  const [showRecord, setShowRecord] = useState(false);
   const userInfo = useSelector((state) => state.user.userInfo);
 
   async function handleAsk() {
@@ -76,6 +78,10 @@ export default function Ask({ onBack = () => {} }) {
     }
   }
 
+  function handleRecord() {
+    setShowRecord(true);
+  }
+
   return (
     <div className="ask-form" data-testid="ask-form">
       <div className="view-header">
@@ -101,6 +107,14 @@ export default function Ask({ onBack = () => {} }) {
       >
         Smooth
       </button>
+      <button
+        type="button"
+        className="mic-button"
+        aria-label="Record"
+        onClick={handleRecord}
+      >
+        <FaMicrophone />
+      </button>
       {message && <p>{message}</p>}
       <footer className="view-footer">
         <button type="button" className="back-button" onClick={onBack}>
@@ -123,6 +137,18 @@ export default function Ask({ onBack = () => {} }) {
               </button>
               <button type="button" onClick={() => setShowSmooth(false)}>
                 Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+      {showRecord && (
+        <div className="popup-overlay" data-testid="record-popup">
+          <div className="popup-window">
+            <p>Recording started...</p>
+            <div className="popup-buttons">
+              <button type="button" onClick={() => setShowRecord(false)}>
+                Close
               </button>
             </div>
           </div>

--- a/frontend/src/Ask.test.jsx
+++ b/frontend/src/Ask.test.jsx
@@ -71,4 +71,12 @@ describe('Ask view', () => {
     expect(screen.queryByTestId('smooth-popup')).not.toBeInTheDocument();
     expect(screen.getByTestId('ask-textarea').value).toBe('fixed');
   });
+
+  it('shows recording popup when microphone clicked', () => {
+    renderWithStore(<Ask />);
+    fireEvent.click(screen.getByRole('button', { name: /record/i }));
+    expect(screen.getByTestId('record-popup')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(screen.queryByTestId('record-popup')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -165,6 +165,17 @@ body.desktop .login-form {
   font-size: 0.9rem;
 }
 
+.mic-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem;
+  font-size: 1.5rem;
+}
+
 /* Ask view layout */
 
 .ask-form {


### PR DESCRIPTION
## Summary
- add microphone button in Ask view
- open popup to show recording message
- style new mic button
- test microphone popup behaviour

## Testing
- `npx vitest run` *(fails: vitest not found because package install requires network)*

------
https://chatgpt.com/codex/tasks/task_e_68532fd33b04832798393ec6822147ae