### PR TITLE
Add restart step to prod deploy workflow

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -12,3 +12,34 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install sshpass
+        run: sudo apt-get update && sudo apt-get install -y sshpass
+      - name: Restart backend and frontend
+        env:
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_PASSWORD: ${{ secrets.SSH_PASSWORD }}
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SERVER_HOME: ${{ vars.SERVER_HOME }}
+          FRONTEND_HOME: ${{ vars.FRONTEND_HOME }}
+          SERVER_SCRIPT: ${{ vars.SERVER_SCRIPT }}
+          FRONTEND_SCRIPT: ${{ vars.FRONTEND_SCRIPT }}
+        run: |
+          set -e
+          for attempt in 1 2 3; do
+            output=$(ATTEMPT="$attempt" ./scripts/restart-services.sh 2>&1)
+            status=$?
+            echo "$output"
+            if [ $status -ne 0 ]; then
+              exit $status
+            fi
+            if ! echo "$output" | grep -q "Another restart is in progress. Exiting."; then
+              exit 0
+            fi
+            if [ $attempt -eq 3 ]; then
+              echo "give up"
+              exit 0
+            fi
+            sleep_time=$((30 + RANDOM % 21 + 10))
+            echo "Another restart in progress during attempt #$attempt. Wait ${sleep_time}s before retry #$((attempt+1))"
+            sleep "$sleep_time"
+          done


### PR DESCRIPTION
## Summary
- restart backend and frontend in `deploy-prod.yml`

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68533ca163b88327b633d7b228016226