### PR TITLE
Add audio recording popup with duration

### DIFF
--- a/frontend/src/Ask.test.jsx
+++ b/frontend/src/Ask.test.jsx
@@ -72,11 +72,29 @@ describe('Ask view', () => {
     expect(screen.getByTestId('ask-textarea').value).toBe('fixed');
   });
 
-  it('shows recording popup when microphone clicked', () => {
+  it('records audio and shows length', async () => {
+    const mockStream = { getTracks: vi.fn(() => [{ stop: vi.fn() }]) };
+    global.navigator.mediaDevices = {
+      getUserMedia: vi.fn(() => Promise.resolve(mockStream)),
+    };
+    global.MediaRecorder = vi.fn(function (stream) {
+      this.stream = stream;
+      this.start = vi.fn();
+      this.stop = vi.fn();
+    });
+
     renderWithStore(<Ask />);
     fireEvent.click(screen.getByRole('button', { name: /record/i }));
-    expect(screen.getByTestId('record-popup')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('record-popup')).toBeInTheDocument();
+    });
+
     fireEvent.click(screen.getByRole('button', { name: /close/i }));
-    expect(screen.queryByTestId('record-popup')).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('record-popup')).not.toBeInTheDocument();
+      expect(screen.getByTestId('length-popup')).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- record audio when clicking the mic button on Ask view
- show popup with recording length after closing the recording
- update tests for new recording flow

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_68534c1941148327a9f0d059a7fc6e67