### PR TITLE
Allow /version endpoint without auth

### DIFF
--- a/server/src/main/java/com/memoritta/server/config/SecurityConfig.java
+++ b/server/src/main/java/com/memoritta/server/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
                         // allow preflight OPTIONS for all endpoints
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         // public endpoints
-                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/login", "/user")
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/login", "/user", "/version")
                         .permitAll()
                         // everything else needs authentication
                         .anyRequest().authenticated()


### PR DESCRIPTION
## Summary
- allow `/version` endpoint through Spring Security

## Testing
- `mvn -q -pl server test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6853545213fc832794ad622c3419a0e3