### PR TITLE
List all question UUIDs

### DIFF
--- a/frontend/src/Questions.jsx
+++ b/frontend/src/Questions.jsx
@@ -24,30 +24,12 @@ export default function Questions({ onBack = () => {} }) {
       try {
         const token = btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`);
         const headers = { Authorization: `Basic ${token}` };
-        const resp = await fetch(
-          `${BACKEND_URL}/question/ids?userId=${userInfo.id}`,
-          { headers }
-        );
+        const resp = await fetch(`${BACKEND_URL}/question/ids/all`, {
+          headers,
+        });
         if (!cancelled && resp.ok) {
           const ids = await resp.json();
           setQuestions(ids.map((id) => ({ id, description: id })));
-          for (const id of ids) {
-            if (cancelled) {
-              break;
-            }
-            const qResp = await fetch(
-              `${BACKEND_URL}/question/detail?id=${id}`,
-              { headers }
-            );
-            if (!cancelled && qResp.ok) {
-              const data = await qResp.json();
-              setQuestions((prev) =>
-                prev.map((q) =>
-                  q.id === id ? { id, description: data.question } : q
-                )
-              );
-            }
-          }
         }
       } catch (err) {
         // ignore errors

--- a/frontend/src/Questions.test.jsx
+++ b/frontend/src/Questions.test.jsx
@@ -26,31 +26,23 @@ describe('Questions view', () => {
 
   it('loads questions on mount', async () => {
     const ids = ['q1', 'q2'];
-    const q1 = { question: 'short' };
-    const q2 = { question: 'a'.repeat(140) };
     global.fetch = vi
       .fn()
       .mockImplementationOnce(() =>
         Promise.resolve({ ok: true, json: () => Promise.resolve(ids) })
-      )
-      .mockImplementationOnce(() =>
-        Promise.resolve({ ok: true, json: () => Promise.resolve(q1) })
-      )
-      .mockImplementationOnce(() =>
-        Promise.resolve({ ok: true, json: () => Promise.resolve(q2) })
       );
     renderWithStore(<Questions />);
-    await screen.findByText('short');
+    for (const id of ids) {
+      expect(await screen.findByText(id)).toBeInTheDocument();
+    }
     expect(global.fetch).toHaveBeenCalledWith(
-      `${BACKEND_URL}/question/ids?userId=u1`,
+      `${BACKEND_URL}/question/ids/all`,
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: `Basic ${btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`)}`,
         }),
       })
     );
-    expect(screen.getByText('short')).toBeInTheDocument();
-    expect(screen.getByText(`${'a'.repeat(125)}...`)).toBeInTheDocument();
   });
 
   it('opens details view on click', async () => {
@@ -61,16 +53,16 @@ describe('Questions view', () => {
         Promise.resolve({ ok: true, json: () => Promise.resolve(ids) })
       )
       .mockImplementationOnce(() =>
-        Promise.resolve({ ok: true, json: () => Promise.resolve({ question: 'short' }) })
-      )
-      .mockImplementationOnce(() =>
-        Promise.resolve({ ok: true, json: () => Promise.resolve({ question: 'q' }) })
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ question: 'q' }),
+        })
       )
       .mockImplementationOnce(() =>
         Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
       );
     renderWithStore(<Questions />);
-    const item = await screen.findByText('short');
+    const item = await screen.findByText('q1');
     fireEvent.click(item);
     await screen.findByRole('heading', { name: 'Question details' });
     expect(global.fetch).toHaveBeenCalledWith(

--- a/server/src/main/java/com/memoritta/server/controller/QuestionController.java
+++ b/server/src/main/java/com/memoritta/server/controller/QuestionController.java
@@ -48,6 +48,12 @@ public class QuestionController {
         return questionManager.listQuestionIdsForUser(UUID.fromString(userId));
     }
 
+    @GetMapping("/ids/all")
+    @Operation(summary = "List all question IDs", description = "Lists IDs of all questions in the database")
+    public List<UUID> listAllQuestionIds() {
+        return questionManager.listAllQuestionIds();
+    }
+
     @GetMapping("/detail")
     @Operation(summary = "Get question", description = "Fetch single question with answers")
     public Question fetchQuestion(

--- a/server/src/main/java/com/memoritta/server/manager/QuestionManager.java
+++ b/server/src/main/java/com/memoritta/server/manager/QuestionManager.java
@@ -57,6 +57,12 @@ public class QuestionManager {
                 .toList();
     }
 
+    public List<UUID> listAllQuestionIds() {
+        return questionRepository.findAll().stream()
+                .map(QuestionDao::getId)
+                .toList();
+    }
+
     private QuestionRef toQuestionRef(QuestionDao dao) {
         String desc = dao.getQuestion();
         if (desc != null && desc.length() > descriptionMaxLength) {

--- a/server/src/test/java/com/memoritta/server/controller/QuestionControllerTest.java
+++ b/server/src/test/java/com/memoritta/server/controller/QuestionControllerTest.java
@@ -102,6 +102,20 @@ class QuestionControllerTest {
     }
 
     @Test
+    void listAllQuestionIds_shouldReturnAll() {
+        UUID id1 = UUID.randomUUID();
+        UUID id2 = UUID.randomUUID();
+        when(questionRepository.findAll()).thenReturn(List.of(
+                QuestionDao.builder().id(id1).build(),
+                QuestionDao.builder().id(id2).build()
+        ));
+
+        List<UUID> result = questionController.listAllQuestionIds();
+
+        assertThat(result).containsExactly(id1, id2);
+    }
+
+    @Test
     void fetchQuestion_shouldReturnWithAnswers() {
         UUID qid = UUID.randomUUID();
         when(questionRepository.findById(qid))

--- a/server/src/test/java/com/memoritta/server/manager/QuestionManagerTest.java
+++ b/server/src/test/java/com/memoritta/server/manager/QuestionManagerTest.java
@@ -125,6 +125,20 @@ class QuestionManagerTest {
     }
 
     @Test
+    void listAllQuestionIds_shouldReturnIds() {
+        UUID id1 = UUID.randomUUID();
+        UUID id2 = UUID.randomUUID();
+        when(questionRepository.findAll()).thenReturn(List.of(
+                QuestionDao.builder().id(id1).build(),
+                QuestionDao.builder().id(id2).build()
+        ));
+
+        List<UUID> result = questionManager.listAllQuestionIds();
+
+        assertThat(result).containsExactly(id1, id2);
+    }
+
+    @Test
     void updateQuestion_shouldSaveChangedText() {
         UUID id = UUID.randomUUID();
         QuestionDao dao = QuestionDao.builder().id(id).question("old").build();


### PR DESCRIPTION
## Summary
- add endpoint to list all question IDs
- display all question IDs in Questions view
- adjust frontend and backend tests

## Testing
- `npm test --prefix frontend`
- `mvn -q -f server/pom.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685354a53ec48327b3e660d425fcdea5