### PR TITLE
Fix ServerControllerTest bean configuration

### DIFF
--- a/server/src/test/java/com/memoritta/server/controller/ServerControllerTest.java
+++ b/server/src/test/java/com/memoritta/server/controller/ServerControllerTest.java
@@ -1,6 +1,7 @@
 package com.memoritta.server.controller;
 
 import com.memoritta.server.config.ServerConfig;
+import com.memoritta.server.config.LogConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -13,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest
-@ContextConfiguration(classes = {ServerController.class, ServerConfig.class})
+@ContextConfiguration(classes = {ServerController.class, ServerConfig.class, LogConfig.class})
 class ServerControllerTest {
 
     @Autowired


### PR DESCRIPTION
## Summary
- include `LogConfig` in test configuration for `ServerController`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6853ac5d70cc8327a17f7f9a811947ab