### PR TITLE
Add audio transcription feature

### DIFF
--- a/server/src/main/java/com/memoritta/server/config/OpenAiConfig.java
+++ b/server/src/main/java/com/memoritta/server/config/OpenAiConfig.java
@@ -9,7 +9,8 @@ import org.springframework.context.annotation.Configuration;
 @Getter
 @Setter
 public class OpenAiConfig {
-    @Value("${openai.url:https://api.openai.com/v1/chat/completions}")
+    // Base URL for OpenAI services. Do not include the path to a specific endpoint.
+    @Value("${openai.url:https://api.openai.com/v1}")
     private String url;
 
     @Value("${openai.api-key:changeme}")

--- a/server/src/main/java/com/memoritta/server/controller/AiController.java
+++ b/server/src/main/java/com/memoritta/server/controller/AiController.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @AllArgsConstructor
@@ -22,5 +24,15 @@ public class AiController {
     )
     public String smooth(@RequestBody String text) {
         return openAiManager.smoothText(text);
+    }
+
+    @PostMapping("/transcribe")
+    @Operation(
+            summary = "Transcribe audio",
+            description = "Uses OpenAI Whisper to transcribe provided audio file"
+    )
+    public String transcribe(@RequestParam("file") MultipartFile file) throws Exception {
+        byte[] data = file.getBytes();
+        return openAiManager.transcribeAudio(data);
     }
 }

--- a/server/src/test/java/com/memoritta/server/controller/AiControllerTest.java
+++ b/server/src/test/java/com/memoritta/server/controller/AiControllerTest.java
@@ -10,6 +10,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import org.springframework.mock.web.MockMultipartFile;
+
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
@@ -43,5 +46,15 @@ class AiControllerTest {
         String result = aiController.smooth("test");
 
         assertThat(result).isEqualTo("done");
+    }
+
+    @Test
+    void transcribe_shouldReturnText() throws Exception {
+        when(openAiManager.transcribeAudio(any())).thenReturn("hello");
+        MockMultipartFile file = new MockMultipartFile("file", new byte[] {1, 2});
+
+        String result = aiController.transcribe(file);
+
+        assertThat(result).isEqualTo("hello");
     }
 }


### PR DESCRIPTION
## Summary
- send recorded audio to the backend and append transcript text in the Ask view
- allow AiController to transcribe audio using OpenAI
- support audio transcription in OpenAiManager
- use the base OpenAI URL in configuration
- test the new behaviour in Ask view and AiController

## Testing
- `npm test --silent`
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853534e35d88327b30a05e6147037ab