### PR TITLE
Add delete item feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This project is being developed as a showcase of skills and as a practical tool 
 - **Mobile-Friendly:** Designed with mobile applications in mind for ease of use.
 - **Open Source:** Built with collaboration in mind, allowing contributions from others.
 - **Learning-Oriented:** Created as a platform for experimenting with new technologies and gaining practical experience.
+- **Item Removal:** Delete items when they are no longer needed.
 
 ---
 

--- a/server/src/main/java/com/memoritta/server/controller/ItemController.java
+++ b/server/src/main/java/com/memoritta/server/controller/ItemController.java
@@ -159,4 +159,17 @@ public class ItemController {
         return itemManager.listItemsByBarcode(barcode);
     }
 
+    @DeleteMapping("/item/{id}")
+    @Operation(
+            summary = "Delete item",
+            description = "Removes an item using its UUID"
+    )
+    public void deleteItem(
+            @PathVariable
+            @Parameter(description = "UUID of the item to delete")
+            String id
+    ) {
+        itemManager.deleteItem(id);
+    }
+
 }

--- a/server/src/main/java/com/memoritta/server/manager/ItemManager.java
+++ b/server/src/main/java/com/memoritta/server/manager/ItemManager.java
@@ -188,4 +188,13 @@ public class ItemManager {
                 .map(ItemDao::getId)
                 .toList();
     }
+
+    /**
+     * Delete an item by its ID.
+     *
+     * @param id the item UUID as string
+     */
+    public void deleteItem(String id) {
+        itemRepository.deleteById(UUID.fromString(id));
+    }
 }

--- a/server/src/test/java/integration/DeleteItemIT.java
+++ b/server/src/test/java/integration/DeleteItemIT.java
@@ -1,0 +1,47 @@
+package integration;
+
+import io.restassured.RestAssured;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.junit.jupiter.EnabledIf;
+
+import java.io.File;
+import java.util.UUID;
+
+import static integration.IntegrationTestUtil.assumeServerRunning;
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@Tag("integration")
+public class DeleteItemIT {
+
+    @EnabledIf(expression = "#{systemEnvironment['PROD'] == null}", reason = "Disabled in PROD environment")
+    @Test
+    void testDeleteItem() throws Exception {
+        assumeServerRunning();
+        RestAssured.baseURI = "http://127.0.0.1:9090";
+
+        File file = new File("src/test/resources/picture.jpg");
+        assertThat(file.exists()).isTrue();
+
+        UUID createdId = given()
+                .auth().basic("admin", "admin")
+                .multiPart("picture", file)
+                .param("name", "delete item")
+                .when()
+                .post("/item")
+                .then()
+                .statusCode(200)
+                .extract()
+                .as(UUID.class);
+
+        given()
+                .auth().basic("admin", "admin")
+                .when()
+                .delete("/item/" + createdId)
+                .then()
+                .statusCode(200);
+    }
+}


### PR DESCRIPTION
## Summary
- add `deleteItem` method to `ItemManager`
- expose `DELETE /item/{id}` endpoint in `ItemController`
- document new capability in `README`
- create integration test for deleting an item

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686a22045710832799f1d835804c44bc