### PR TITLE
Add item deletion UI

### DIFF
--- a/frontend/src/Search.jsx
+++ b/frontend/src/Search.jsx
@@ -8,6 +8,26 @@ export default function Search({ onBack = () => {} }) {
   const [details, setDetails] = useState({});
   const [selectedId, setSelectedId] = useState(null);
 
+  async function handleDelete(id) {
+    try {
+      const token = btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`);
+      const resp = await fetch(`${BACKEND_URL}/item/${id}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Basic ${token}` },
+      });
+      if (resp.ok) {
+        setItemIds((prev) => prev.filter((itemId) => itemId !== id));
+        setDetails((prev) => {
+          const { [id]: _omit, ...rest } = prev;
+          return rest;
+        });
+        setSelectedId(null);
+      }
+    } catch (err) {
+      // Ignore errors
+    }
+  }
+
   useEffect(() => {
     async function fetchItems() {
       try {
@@ -91,6 +111,7 @@ export default function Search({ onBack = () => {} }) {
         onUpdate={(data) =>
           setDetails((prev) => ({ ...prev, [selectedId]: data }))
         }
+        onDelete={() => handleDelete(selectedId)}
       />
     );
   }

--- a/frontend/src/Search.test.jsx
+++ b/frontend/src/Search.test.jsx
@@ -111,4 +111,37 @@ describe('Search view', () => {
     );
     expect(screen.getByText('789')).toBeInTheDocument();
   });
+
+  it('deletes item from details view', async () => {
+    const ids = ['del1'];
+    const item = { name: 'ToDelete', description: {} };
+    global.fetch = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(ids) })
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(item) })
+      )
+      .mockImplementationOnce(() => Promise.resolve({ ok: true }));
+
+    render(<Search />);
+    const itemEl = await screen.findByText('ToDelete');
+    fireEvent.click(itemEl);
+    await screen.findByRole('button', { name: 'Delete' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await screen.findByRole('heading', { name: 'Search' });
+    expect(global.fetch).toHaveBeenLastCalledWith(
+      `${BACKEND_URL}/item/del1`,
+      expect.objectContaining({
+        method: 'DELETE',
+        headers: expect.objectContaining({
+          Authorization: `Basic ${btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`)}`,
+        }),
+      })
+    );
+    expect(screen.queryByText('ToDelete')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- allow deleting items in Search view
- test removing items via API

## Testing
- `npm test`
- `mvn -q -pl server test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686a2e0cc7a08327ac95159453048847