### PR TITLE
Add query-based item fetch endpoint

### DIFF
--- a/frontend/src/ItemDetails.jsx
+++ b/frontend/src/ItemDetails.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { FaBarcode } from 'react-icons/fa';
 import { BACKEND_URL, AUTH_EMAIL, AUTH_PASSWORD } from './config.js';
+import { getItemById } from './backend.js';
 
 export default function ItemDetails({
   id,
@@ -17,10 +18,7 @@ export default function ItemDetails({
     let cancelled = false;
     async function load() {
       try {
-        const token = btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`);
-        const resp = await fetch(`${BACKEND_URL}/item?id=${id}`, {
-          headers: { Authorization: `Basic ${token}` },
-        });
+        const resp = await getItemById(id);
         if (!cancelled && resp.ok) {
           const result = await resp.json();
           setData(result);

--- a/frontend/src/Search.jsx
+++ b/frontend/src/Search.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { FaBarcode } from 'react-icons/fa';
 import { BACKEND_URL, AUTH_EMAIL, AUTH_PASSWORD } from './config.js';
+import { getItemById } from './backend.js';
 import ItemDetails from './ItemDetails.jsx';
 
 export default function Search({ onBack = () => {} }) {
@@ -54,10 +55,7 @@ export default function Search({ onBack = () => {} }) {
     let cancelled = false;
     async function fetchDetail() {
       try {
-        const token = btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`);
-        const resp = await fetch(`${BACKEND_URL}/item?id=${selectedId}`, {
-          headers: { Authorization: `Basic ${token}` },
-        });
+        const resp = await getItemById(selectedId);
         if (!cancelled && resp.ok) {
           const data = await resp.json();
           setDetails((prev) => ({ ...prev, [selectedId]: data }));
@@ -83,10 +81,7 @@ export default function Search({ onBack = () => {} }) {
           continue;
         }
         try {
-          const token = btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`);
-          const resp = await fetch(`${BACKEND_URL}/item?id=${id}`, {
-            headers: { Authorization: `Basic ${token}` },
-          });
+          const resp = await getItemById(id);
           if (!cancelled && resp.ok) {
             const data = await resp.json();
             setDetails((prev) => ({ ...prev, [id]: data }));

--- a/frontend/src/backend.js
+++ b/frontend/src/backend.js
@@ -11,3 +11,8 @@ export async function backendFetch(path, options = {}) {
   const response = await fetch(`${BACKEND_URL}${path}`, opts);
   return response;
 }
+
+// Fetch a single item using the query-based endpoint.
+export function getItemById(id) {
+  return backendFetch(`/item?id=${encodeURIComponent(id)}`);
+}

--- a/server/src/main/java/com/memoritta/server/controller/ItemController.java
+++ b/server/src/main/java/com/memoritta/server/controller/ItemController.java
@@ -112,6 +112,25 @@ public class ItemController {
         return itemManager.fetchItem(id);
     }
 
+    /**
+     * Fetches an item by its UUID using a query parameter.
+     *
+     * @param id the UUID of the item to fetch
+     * @return the full item object
+     */
+    @GetMapping("/item")
+    @Operation(
+            summary = "Fetch a single item by ID using query parameter",
+            description = "Returns the full item object for the provided UUID via query parameter."
+    )
+    public Item fetchItemByParam(
+            @RequestParam
+            @Parameter(description = "UUID of the item to retrieve", example = "123e4567-e89b-12d3-a456-426614174000")
+            String id
+    ) throws IOException {
+        return fetchItem(id);
+    }
+
 
     @PostMapping("/items/user")
     @Operation(


### PR DESCRIPTION
## Summary
- add a new `/item` GET endpoint that accepts `id` as request parameter
- document the new method with OpenAPI annotations
- use the new query-based endpoint in the frontend via `getItemById` helper

## Testing
- `npm test --silent` *(fails: vitest not found)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a8ff812a4832786725aba76fca00a