### PR TITLE
Add exception handler for HTTP method not allowed

### DIFF
--- a/server/src/main/java/com/memoritta/server/advice/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/memoritta/server/advice/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 
 import java.util.NoSuchElementException;
 
@@ -34,6 +35,13 @@ public class GlobalExceptionHandler {
         log.warn("Missing request parameter: {}", ex.getParameterName());
         String message = "Missing required parameter: " + ex.getParameterName();
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(message);
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<String> handleMethodNotSupported(HttpRequestMethodNotSupportedException ex) {
+        log.warn("Unsupported method: {}", ex.getMethod());
+        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED)
+                             .body("Method not allowed");
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
## Summary
- handle `HttpRequestMethodNotSupportedException` in global exception handler

## Testing
- `./mvnw -q -pl server -am test` *(fails: No such file or directory)*
- `mvn -q -pl server -am test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a9009bb9c832780c78af917caa1fe