### PR TITLE
Add item thumbnails

### DIFF
--- a/frontend/src/Search.test.jsx
+++ b/frontend/src/Search.test.jsx
@@ -96,20 +96,44 @@ describe('Search view', () => {
         })
       );
     render(<Search />);
+    await screen.findByAltText('Item');
     const itemEl = await screen.findByText('Beer');
     global.fetch.mockClear();
     fireEvent.click(itemEl);
-    await screen.findByAltText('Item');
-    expect(global.fetch).toHaveBeenCalledTimes(1);
-    expect(global.fetch).toHaveBeenCalledWith(
-      `${BACKEND_URL}/data?id=pic1`,
+    await screen.findByText('789');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('shows thumbnail for items with picture', async () => {
+    const ids = ['t1'];
+    const item = {
+      name: 'Thumb',
+      description: { pictures: [{ id: 'pic2' }] },
+    };
+    global.fetch = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(ids) })
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(item) })
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          arrayBuffer: () => Promise.resolve(new Uint8Array([4]).buffer),
+        })
+      );
+    render(<Search />);
+    expect(await screen.findByAltText('Item')).toBeInTheDocument();
+    expect(global.fetch).toHaveBeenLastCalledWith(
+      `${BACKEND_URL}/data?id=pic2`,
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: `Basic ${btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`)}`,
         }),
       })
     );
-    expect(screen.getByText('789')).toBeInTheDocument();
   });
 
   it('deletes item from details view', async () => {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -131,6 +131,19 @@ h1 {
   height: auto;
 }
 
+.item-button {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.item-thumbnail {
+  width: 40px;
+  height: 40px;
+  object-fit: cover;
+  border-radius: 4px;
+}
+
 body.mobile .login-form {
   width: 90%;
   max-width: none;


### PR DESCRIPTION
## Summary
- load item pictures in search results
- show thumbnails with item names
- style thumbnails and list buttons
- test thumbnail behavior

## Testing
- `npm test`
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686a98be12a08327b6d1c6cce6ed684f