### PR TITLE
Switch item API to path-based URL

### DIFF
--- a/frontend/src/ItemDetails.jsx
+++ b/frontend/src/ItemDetails.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { FaBarcode } from 'react-icons/fa';
 import { BACKEND_URL, AUTH_EMAIL, AUTH_PASSWORD } from './config.js';
-import { getItemById } from './backend.js';
 
 export default function ItemDetails({
   id,
@@ -18,7 +17,10 @@ export default function ItemDetails({
     let cancelled = false;
     async function load() {
       try {
-        const resp = await getItemById(id);
+        const token = btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`);
+        const resp = await fetch(`${BACKEND_URL}/item/${id}`, {
+          headers: { Authorization: `Basic ${token}` },
+        });
         if (!cancelled && resp.ok) {
           const result = await resp.json();
           setData(result);

--- a/frontend/src/ItemDetails.test.jsx
+++ b/frontend/src/ItemDetails.test.jsx
@@ -52,7 +52,7 @@ describe('ItemDetails', () => {
     render(<ItemDetails id="2" />);
     await screen.findByAltText('Item');
     expect(global.fetch).toHaveBeenCalledWith(
-      `${BACKEND_URL}/item?id=2`,
+      `${BACKEND_URL}/item/2`,
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: `Basic ${btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`)}`,

--- a/frontend/src/Search.jsx
+++ b/frontend/src/Search.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { FaBarcode } from 'react-icons/fa';
 import { BACKEND_URL, AUTH_EMAIL, AUTH_PASSWORD } from './config.js';
-import { getItemById } from './backend.js';
 import ItemDetails from './ItemDetails.jsx';
 
 export default function Search({ onBack = () => {} }) {
@@ -55,7 +54,10 @@ export default function Search({ onBack = () => {} }) {
     let cancelled = false;
     async function fetchDetail() {
       try {
-        const resp = await getItemById(selectedId);
+        const token = btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`);
+        const resp = await fetch(`${BACKEND_URL}/item/${selectedId}`, {
+          headers: { Authorization: `Basic ${token}` },
+        });
         if (!cancelled && resp.ok) {
           const data = await resp.json();
           setDetails((prev) => ({ ...prev, [selectedId]: data }));
@@ -81,7 +83,10 @@ export default function Search({ onBack = () => {} }) {
           continue;
         }
         try {
-          const resp = await getItemById(id);
+          const token = btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`);
+          const resp = await fetch(`${BACKEND_URL}/item/${id}`, {
+            headers: { Authorization: `Basic ${token}` },
+          });
           if (!cancelled && resp.ok) {
             const data = await resp.json();
             setDetails((prev) => ({ ...prev, [id]: data }));

--- a/frontend/src/Search.test.jsx
+++ b/frontend/src/Search.test.jsx
@@ -49,7 +49,7 @@ describe('Search view', () => {
     render(<Search />);
     await screen.findByText('Beer');
     expect(global.fetch).toHaveBeenLastCalledWith(
-      `${BACKEND_URL}/item?id=123`,
+      `${BACKEND_URL}/item/123`,
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: `Basic ${btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`)}`,

--- a/frontend/src/backend.js
+++ b/frontend/src/backend.js
@@ -12,7 +12,7 @@ export async function backendFetch(path, options = {}) {
   return response;
 }
 
-// Fetch a single item using the query-based endpoint.
+// Fetch a single item using the path-based endpoint.
 export function getItemById(id) {
-  return backendFetch(`/item?id=${encodeURIComponent(id)}`);
+  return backendFetch(`/item/${encodeURIComponent(id)}`);
 }

--- a/server/src/main/java/com/memoritta/server/controller/ItemController.java
+++ b/server/src/main/java/com/memoritta/server/controller/ItemController.java
@@ -112,24 +112,6 @@ public class ItemController {
         return itemManager.fetchItem(id);
     }
 
-    /**
-     * Fetches an item by its UUID using a query parameter.
-     *
-     * @param id the UUID of the item to fetch
-     * @return the full item object
-     */
-    @GetMapping("/item")
-    @Operation(
-            summary = "Fetch a single item by ID using query parameter",
-            description = "Returns the full item object for the provided UUID via query parameter."
-    )
-    public Item fetchItemByParam(
-            @RequestParam
-            @Parameter(description = "UUID of the item to retrieve", example = "123e4567-e89b-12d3-a456-426614174000")
-            String id
-    ) throws IOException {
-        return fetchItem(id);
-    }
 
 
     @PostMapping("/items/user")


### PR DESCRIPTION
## Summary
- update `ItemDetails` and `Search` components to request items using `/item/{id}`
- adapt backend helper for new path and remove unused query endpoint
- adjust unit tests for the changed URL

## Testing
- `npm test`
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a9a11d6208327893b8722f7a9154f