### PR TITLE
Add item pictures gallery

### DIFF
--- a/frontend/src/ItemDetails.test.jsx
+++ b/frontend/src/ItemDetails.test.jsx
@@ -7,21 +7,43 @@ import { BACKEND_URL, AUTH_EMAIL, AUTH_PASSWORD } from './config.js';
 describe('ItemDetails', () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it('shows provided info and loads picture', async () => {
+  it('shows provided info and loads pictures', async () => {
     const info = {
       name: 'Beer',
-      description: { barcode: '123', note: 'note', pictures: [{ id: 'img1' }] },
+      description: {
+        barcode: '123',
+        note: 'note',
+        pictures: [{ id: 'img1' }, { id: 'img2' }],
+      },
     };
-    global.fetch = vi.fn(() =>
-      Promise.resolve({
-        ok: true,
-        arrayBuffer: () => Promise.resolve(new Uint8Array([1]).buffer),
+    global.fetch = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          arrayBuffer: () => Promise.resolve(new Uint8Array([1]).buffer),
+        })
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: true,
+          arrayBuffer: () => Promise.resolve(new Uint8Array([2]).buffer),
+        })
+      );
+    render(<ItemDetails id="1" info={info} />);
+    expect(await screen.findAllByAltText('Item')).toHaveLength(2);
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      1,
+      `${BACKEND_URL}/data?id=img1`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: `Basic ${btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`)}`,
+        }),
       })
     );
-    render(<ItemDetails id="1" info={info} />);
-    await screen.findByAltText('Item');
-    expect(global.fetch).toHaveBeenCalledWith(
-      `${BACKEND_URL}/data?id=img1`,
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      `${BACKEND_URL}/data?id=img2`,
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: `Basic ${btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`)}`,


### PR DESCRIPTION
## Summary
- show all images connected with an item
- update the ItemDetails test to handle multiple pictures

## Testing
- `npm install --silent`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686ac96397948327965cbb704fa3236c