### PR TITLE
Replace printStackTrace with logger

### DIFF
--- a/server/src/main/java/com/memoritta/server/advice/OpenApiExceptionLogger.java
+++ b/server/src/main/java/com/memoritta/server/advice/OpenApiExceptionLogger.java
@@ -4,12 +4,14 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
 @Component
+@Slf4j
 public class OpenApiExceptionLogger extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -19,7 +21,7 @@ public class OpenApiExceptionLogger extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
         } catch (Throwable t) {
             if (request.getRequestURI().contains("/v3/api-docs")) {
-                t.printStackTrace();
+                log.warn("Error while processing /v3/api-docs: {}", t.getMessage());
             }
             throw t;
         }


### PR DESCRIPTION
## Summary
- use Lombok `@Slf4j` in `OpenApiExceptionLogger`
- log API docs processing error instead of printing stack trace

## Testing
- `mvn -q -pl server test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686acd2fd834832791e8de4857276abb