### PR TITLE
Add popup view for answers

### DIFF
--- a/frontend/src/QuestionDetails.jsx
+++ b/frontend/src/QuestionDetails.jsx
@@ -10,6 +10,8 @@ export default function QuestionDetails({ id, onBack = () => {} }) {
   const [showPopup, setShowPopup] = useState(false);
   const [answerText, setAnswerText] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
+  const [showAnswerPopup, setShowAnswerPopup] = useState(false);
+  const [selectedAnswer, setSelectedAnswer] = useState(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -93,8 +95,18 @@ export default function QuestionDetails({ id, onBack = () => {} }) {
       </div>
       {question && <p>{question.question}</p>}
       <ul>
-        {answers.map((a) => (
-          <li key={a.id}>{a.text}</li>
+        {answers.map((a, idx) => (
+          <li key={a.id}>
+            <button
+              type="button"
+              onClick={() => {
+                setSelectedAnswer(a);
+                setShowAnswerPopup(true);
+              }}
+            >
+              {`Answer ${idx + 1}`}
+            </button>
+          </li>
         ))}
       </ul>
       <footer className="view-footer">
@@ -120,6 +132,18 @@ export default function QuestionDetails({ id, onBack = () => {} }) {
               </button>
               <button type="button" onClick={() => setShowPopup(false)}>
                 Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+      {showAnswerPopup && selectedAnswer && (
+        <div className="popup-overlay" data-testid="show-answer-popup">
+          <div className="popup-window">
+            <p>{selectedAnswer.text}</p>
+            <div className="popup-buttons">
+              <button type="button" onClick={() => setShowAnswerPopup(false)}>
+                Close
               </button>
             </div>
           </div>

--- a/frontend/src/QuestionDetails.test.jsx
+++ b/frontend/src/QuestionDetails.test.jsx
@@ -20,7 +20,10 @@ describe('QuestionDetails', () => {
     global.fetch = vi
       .fn()
       .mockImplementationOnce(() =>
-        Promise.resolve({ ok: true, json: () => Promise.resolve({ question: 'q' }) })
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ question: 'q' }),
+        })
       )
       .mockImplementationOnce(() =>
         Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
@@ -52,6 +55,10 @@ describe('QuestionDetails', () => {
         }),
       })
     );
+    const btn = screen.getByRole('button', { name: /answer 1/i });
+    expect(btn).toBeInTheDocument();
+    fireEvent.click(btn);
+    expect(screen.getByTestId('show-answer-popup')).toBeInTheDocument();
     expect(screen.getByText('ans')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- show a button for each answer in question details
- open a popup with full answer text on click
- update tests for new behavior

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686ad8ba26ec8327b29d86942aefc82a