### PR TITLE
Fix photo upload path

### DIFF
--- a/frontend/src/AddView.jsx
+++ b/frontend/src/AddView.jsx
@@ -141,9 +141,8 @@ export default function AddView({ onBack = () => {} }) {
 
       if (photo) {
         const updateData = new FormData();
-        updateData.append('id', idText);
         updateData.append('pictureBase64', photo.split(',')[1]);
-        await fetch(`${BACKEND_URL}/item`, {
+        await fetch(`${BACKEND_URL}/item/${idText}`, {
           method: 'PUT',
           headers: { Authorization: `Basic ${token}` },
           body: updateData,

--- a/frontend/src/AddView.test.jsx
+++ b/frontend/src/AddView.test.jsx
@@ -296,6 +296,16 @@ describe('AddView', () => {
           }),
         })
       );
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        2,
+        `${BACKEND_URL}/item/id123`,
+        expect.objectContaining({
+          method: 'PUT',
+          headers: expect.objectContaining({
+            Authorization: `Basic ${btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`)}`,
+          }),
+        })
+      );
     });
 
     const postData = global.fetch.mock.calls[0][1].body;
@@ -303,7 +313,7 @@ describe('AddView', () => {
     expect(postData.has('pictureBase64')).toBe(false);
 
     const putData = global.fetch.mock.calls[1][1].body;
-    expect(putData.get('id')).toBe('id123');
+    expect(putData.has('id')).toBe(false);
     expect(putData.get('pictureBase64')).toBe('testimg');
   });
 });


### PR DESCRIPTION
## Summary
- send photos to `/item/{id}` instead of `/item`
- adjust tests for the new upload URL

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686ae5ee8ef88327b2cdcba04d2ed8f3