### PR TITLE
Add Data view for MongoDB items

### DIFF
--- a/frontend/src/Data.jsx
+++ b/frontend/src/Data.jsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { backendFetch } from './backend.js';
+import ItemDetails from './ItemDetails.jsx';
+
+export default function Data({ onBack = () => {} }) {
+  const userInfo = useSelector((state) => state.user.userInfo);
+  const [ids, setIds] = useState([]);
+  const [details, setDetails] = useState({});
+  const [selectedId, setSelectedId] = useState(null);
+
+  useEffect(() => {
+    if (!userInfo) return;
+    let cancelled = false;
+    async function loadIds() {
+      try {
+        const resp = await backendFetch('/items/user', { method: 'POST' });
+        if (!cancelled && resp.ok) {
+          const data = await resp.json();
+          setIds(data);
+        }
+      } catch {
+        // ignore errors
+      }
+    }
+    loadIds();
+    return () => {
+      cancelled = true;
+    };
+  }, [userInfo]);
+
+  useEffect(() => {
+    if (!selectedId || details[selectedId]) return;
+    let cancelled = false;
+    async function load() {
+      try {
+        const resp = await backendFetch(`/item/${selectedId}`);
+        if (!cancelled && resp.ok) {
+          const data = await resp.json();
+          setDetails((prev) => ({ ...prev, [selectedId]: data }));
+        }
+      } catch {
+        // ignore errors
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedId]);
+
+  if (selectedId) {
+    return (
+      <ItemDetails
+        id={selectedId}
+        info={details[selectedId]}
+        onBack={() => setSelectedId(null)}
+        onUpdate={(data) =>
+          setDetails((prev) => ({ ...prev, [selectedId]: data }))
+        }
+      />
+    );
+  }
+
+  return (
+    <div className="data-view">
+      <div className="view-header">
+        <h1>Data</h1>
+        <button type="button" className="back-button" onClick={onBack}>
+          Back
+        </button>
+      </div>
+      <ul>
+        {ids.map((id) => (
+          <li key={id}>
+            <button
+              type="button"
+              className="item-button"
+              onClick={() => setSelectedId(id)}
+            >
+              {details[id] && details[id].name ? details[id].name : id}
+            </button>
+          </li>
+        ))}
+      </ul>
+      <footer className="view-footer">
+        <button type="button" className="back-button" onClick={onBack}>
+          Back
+        </button>
+      </footer>
+    </div>
+  );
+}

--- a/frontend/src/Data.test.jsx
+++ b/frontend/src/Data.test.jsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import { Provider } from 'react-redux';
+import { createAppStore } from './store.js';
+import Data from './Data.jsx';
+import { BACKEND_URL, AUTH_EMAIL, AUTH_PASSWORD } from './config.js';
+
+function renderWithStore(ui) {
+  const store = createAppStore({ user: { userInfo: { id: 'u1' }, currentView: null } });
+  return render(<Provider store={store}>{ui}</Provider>);
+}
+
+describe('Data view', () => {
+  it('shows Data title', () => {
+    renderWithStore(<Data />);
+    expect(screen.getByRole('heading', { name: 'Data' })).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Back' })).toHaveLength(2);
+  });
+
+  it('loads item IDs on mount', async () => {
+    const ids = ['a1', 'a2'];
+    const pending = new Promise(() => {});
+    global.fetch = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(ids) })
+      )
+      .mockImplementation(() => pending);
+    renderWithStore(<Data />);
+    for (const id of ids) {
+      expect(await screen.findByText(id)).toBeInTheDocument();
+    }
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${BACKEND_URL}/items/user`,
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: `Basic ${btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`)}`,
+        }),
+      })
+    );
+  });
+});

--- a/frontend/src/LoginForm.jsx
+++ b/frontend/src/LoginForm.jsx
@@ -7,6 +7,7 @@ import {
   MdQuestionAnswer,
   MdGroup,
   MdSubject,
+  MdStorage,
   MdVisibility,
   MdVisibilityOff,
 } from 'react-icons/md';
@@ -19,6 +20,7 @@ import Search from './Search.jsx';
 import Ask from './Ask.jsx';
 import Questions from './Questions.jsx';
 import Friends from './Friends.jsx';
+import Data from './Data.jsx';
 import Logs from './Logs.jsx';
 
 import { BACKEND_URL, AUTH_EMAIL, AUTH_PASSWORD } from './config.js';
@@ -233,16 +235,21 @@ export default function LoginForm({ onLogin }) {
                   <MdQuestionAnswer /> Questions
                 </button>
               </div>
-              <div>
-                <button onClick={() => dispatch(setCurrentView('friends'))}>
-                  <MdGroup /> Friends
-                </button>
-              </div>
-              <div>
-                <button onClick={() => dispatch(setCurrentView('logs'))}>
-                  <MdSubject /> Logs
-                </button>
-              </div>
+                <div>
+                  <button onClick={() => dispatch(setCurrentView('friends'))}>
+                    <MdGroup /> Friends
+                  </button>
+                </div>
+                <div>
+                  <button onClick={() => dispatch(setCurrentView('data'))}>
+                    <MdStorage /> Data
+                  </button>
+                </div>
+                <div>
+                  <button onClick={() => dispatch(setCurrentView('logs'))}>
+                    <MdSubject /> Logs
+                  </button>
+                </div>
               <footer className="view-footer">
                 <button
                   type="button"
@@ -271,6 +278,9 @@ export default function LoginForm({ onLogin }) {
           )}
           {currentView === 'friends' && (
             <Friends onBack={() => dispatch(setCurrentView(null))} />
+          )}
+          {currentView === 'data' && (
+            <Data onBack={() => dispatch(setCurrentView(null))} />
           )}
           {currentView === 'logs' && (
             <Logs onBack={() => dispatch(setCurrentView(null))} />

--- a/frontend/src/LoginForm.test.jsx
+++ b/frontend/src/LoginForm.test.jsx
@@ -88,6 +88,7 @@ describe('LoginForm', () => {
       screen.getByRole('button', { name: 'Questions' })
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Friends' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Data' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Logs' })).toBeInTheDocument();
     expect(screen.getByText('Server version: 1.0.0')).toBeInTheDocument();
   });
@@ -224,6 +225,10 @@ describe('LoginForm', () => {
       await screen.findByRole('button', { name: 'Friends' });
       fireEvent.click(screen.getByRole('button', { name: 'Friends' }));
       await screen.findByRole('heading', { name: 'Friends' });
+      fireEvent.click(screen.getAllByRole('button', { name: 'Back' })[0]);
+      await screen.findByRole('button', { name: 'Data' });
+      fireEvent.click(screen.getByRole('button', { name: 'Data' }));
+      await screen.findByRole('heading', { name: 'Data' });
       fireEvent.click(screen.getAllByRole('button', { name: 'Back' })[0]);
       await screen.findByRole('button', { name: 'Logs' });
       fireEvent.click(screen.getByRole('button', { name: 'Logs' }));


### PR DESCRIPTION
## Summary
- add new Data view component
- support browsing item data from MongoDB
- include Data view in Login menu
- test Data view and update LoginForm tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686af7049f7c832796a4d723325fbc4f