### PR TITLE
Add collection selector to Data view

### DIFF
--- a/frontend/src/Data.jsx
+++ b/frontend/src/Data.jsx
@@ -2,20 +2,33 @@ import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { backendFetch } from './backend.js';
 import ItemDetails from './ItemDetails.jsx';
+import QuestionDetails from './QuestionDetails.jsx';
 
 export default function Data({ onBack = () => {} }) {
   const userInfo = useSelector((state) => state.user.userInfo);
   const [ids, setIds] = useState([]);
   const [details, setDetails] = useState({});
   const [selectedId, setSelectedId] = useState(null);
+  const [collection, setCollection] = useState('items');
+
+  useEffect(() => {
+    setIds([]);
+    setDetails({});
+    setSelectedId(null);
+  }, [collection]);
 
   useEffect(() => {
     if (!userInfo) return;
     let cancelled = false;
     async function loadIds() {
       try {
-        const resp = await backendFetch('/items/user', { method: 'POST' });
-        if (!cancelled && resp.ok) {
+        let resp;
+        if (collection === 'items') {
+          resp = await backendFetch('/items/user', { method: 'POST' });
+        } else if (collection === 'questions') {
+          resp = await backendFetch('/question/ids/all');
+        }
+        if (resp && !cancelled && resp.ok) {
           const data = await resp.json();
           setIds(data);
         }
@@ -27,15 +40,20 @@ export default function Data({ onBack = () => {} }) {
     return () => {
       cancelled = true;
     };
-  }, [userInfo]);
+  }, [userInfo, collection]);
 
   useEffect(() => {
     if (!selectedId || details[selectedId]) return;
     let cancelled = false;
     async function load() {
       try {
-        const resp = await backendFetch(`/item/${selectedId}`);
-        if (!cancelled && resp.ok) {
+        let resp;
+        if (collection === 'items') {
+          resp = await backendFetch(`/item/${selectedId}`);
+        } else if (collection === 'questions') {
+          resp = await backendFetch(`/question/detail?id=${selectedId}`);
+        }
+        if (resp && !cancelled && resp.ok) {
           const data = await resp.json();
           setDetails((prev) => ({ ...prev, [selectedId]: data }));
         }
@@ -47,25 +65,40 @@ export default function Data({ onBack = () => {} }) {
     return () => {
       cancelled = true;
     };
-  }, [selectedId]);
+  }, [selectedId, collection]);
 
   if (selectedId) {
-    return (
-      <ItemDetails
-        id={selectedId}
-        info={details[selectedId]}
-        onBack={() => setSelectedId(null)}
-        onUpdate={(data) =>
-          setDetails((prev) => ({ ...prev, [selectedId]: data }))
-        }
-      />
-    );
+    if (collection === 'items') {
+      return (
+        <ItemDetails
+          id={selectedId}
+          info={details[selectedId]}
+          onBack={() => setSelectedId(null)}
+          onUpdate={(data) =>
+            setDetails((prev) => ({ ...prev, [selectedId]: data }))
+          }
+        />
+      );
+    }
+    if (collection === 'questions') {
+      return (
+        <QuestionDetails id={selectedId} onBack={() => setSelectedId(null)} />
+      );
+    }
   }
 
   return (
     <div className="data-view">
       <div className="view-header">
         <h1>Data</h1>
+        <select
+          value={collection}
+          onChange={(e) => setCollection(e.target.value)}
+          aria-label="collection selector"
+        >
+          <option value="items">Items</option>
+          <option value="questions">Questions</option>
+        </select>
         <button type="button" className="back-button" onClick={onBack}>
           Back
         </button>

--- a/frontend/src/Data.test.jsx
+++ b/frontend/src/Data.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import { Provider } from 'react-redux';
@@ -7,15 +7,19 @@ import Data from './Data.jsx';
 import { BACKEND_URL, AUTH_EMAIL, AUTH_PASSWORD } from './config.js';
 
 function renderWithStore(ui) {
-  const store = createAppStore({ user: { userInfo: { id: 'u1' }, currentView: null } });
+  const store = createAppStore({
+    user: { userInfo: { id: 'u1' }, currentView: null },
+  });
   return render(<Provider store={store}>{ui}</Provider>);
 }
 
 describe('Data view', () => {
-  it('shows Data title', () => {
+  afterEach(() => vi.restoreAllMocks());
+  it('shows Data title and selector', () => {
     renderWithStore(<Data />);
     expect(screen.getByRole('heading', { name: 'Data' })).toBeInTheDocument();
     expect(screen.getAllByRole('button', { name: 'Back' })).toHaveLength(2);
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
   });
 
   it('loads item IDs on mount', async () => {
@@ -28,6 +32,7 @@ describe('Data view', () => {
       )
       .mockImplementation(() => pending);
     renderWithStore(<Data />);
+    expect(screen.getByRole('combobox')).toHaveValue('items');
     for (const id of ids) {
       expect(await screen.findByText(id)).toBeInTheDocument();
     }
@@ -35,6 +40,32 @@ describe('Data view', () => {
       `${BACKEND_URL}/items/user`,
       expect.objectContaining({
         method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: `Basic ${btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`)}`,
+        }),
+      })
+    );
+  });
+
+  it('switches to questions collection', async () => {
+    const ids = ['q1', 'q2'];
+    global.fetch = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(ids) })
+      );
+    renderWithStore(<Data />);
+    const select = screen.getByRole('combobox');
+    fireEvent.change(select, { target: { value: 'questions' } });
+    for (const id of ids) {
+      expect(await screen.findByText(id)).toBeInTheDocument();
+    }
+    expect(global.fetch).toHaveBeenLastCalledWith(
+      `${BACKEND_URL}/question/ids/all`,
+      expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: `Basic ${btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`)}`,
         }),


### PR DESCRIPTION
## Summary
- add selector in Data view so user can pick 'items' or 'questions'
- fetch data based on chosen collection
- update tests for new selector and fetching logic

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686afb4c17188327a22d37520d887895