### PR TITLE
Add friends collection to Data view

### DIFF
--- a/frontend/src/Data.test.jsx
+++ b/frontend/src/Data.test.jsx
@@ -72,4 +72,34 @@ describe('Data view', () => {
       })
     );
   });
+
+  it('switches to friends collection', async () => {
+    const relations = [
+      { id: 'r1', friendId: 'f1', type: 'FRIENDS' },
+      { id: 'r2', friendId: 'f2', type: 'BEST_FRIENDS' },
+    ];
+    global.fetch = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(relations) })
+      );
+    renderWithStore(<Data />);
+    const select = screen.getByRole('combobox');
+    fireEvent.change(select, { target: { value: 'friends' } });
+    for (const r of relations) {
+      const text = `${r.friendId} - ${r.type}`;
+      expect(await screen.findByText(text)).toBeInTheDocument();
+    }
+    expect(global.fetch).toHaveBeenLastCalledWith(
+      `${BACKEND_URL}/friend?userId=u1`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: `Basic ${btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`)}`,
+        }),
+      })
+    );
+  });
 });

--- a/frontend/src/FriendDetails.jsx
+++ b/frontend/src/FriendDetails.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export default function FriendDetails({ relation, onBack = () => {} }) {
+  if (!relation) return null;
+  return (
+    <div className="friend-details-view">
+      <div className="view-header">
+        <h1>Friend relation</h1>
+        <button type="button" className="back-button" onClick={onBack}>
+          Back
+        </button>
+      </div>
+      <p>{`Friend ID: ${relation.friendId}`}</p>
+      <p>{`Type: ${relation.type}`}</p>
+      <footer className="view-footer">
+        <button type="button" className="back-button" onClick={onBack}>
+          Back
+        </button>
+      </footer>
+    </div>
+  );
+}

--- a/frontend/src/FriendDetails.test.jsx
+++ b/frontend/src/FriendDetails.test.jsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import FriendDetails from './FriendDetails.jsx';
+
+describe('FriendDetails', () => {
+  it('shows friend info', () => {
+    const relation = { id: 'r1', friendId: 'f1', type: 'FRIENDS' };
+    render(<FriendDetails relation={relation} />);
+    expect(screen.getByText('Friend relation')).toBeInTheDocument();
+    expect(screen.getByText('Friend ID: f1')).toBeInTheDocument();
+    expect(screen.getByText('Type: FRIENDS')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- enable showing friend relations in Data view
- add FriendDetails component
- test Data view for switching to friends
- cover FriendDetails in tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686b76bfae34832792ccad5317d57ef6