### PR TITLE
Fix photos from mobile

### DIFF
--- a/frontend/src/AddView.jsx
+++ b/frontend/src/AddView.jsx
@@ -116,7 +116,7 @@ export default function AddView({ onBack = () => {} }) {
     canvas.height = video.videoHeight;
     const ctx = canvas.getContext('2d');
     ctx.drawImage(video, 0, 0);
-    const dataUrl = canvas.toDataURL('image/png');
+    const dataUrl = canvas.toDataURL('image/jpeg');
     setPhoto(dataUrl);
 
     addDebug('Photo captured');

--- a/frontend/src/AddView.test.jsx
+++ b/frontend/src/AddView.test.jsx
@@ -179,7 +179,7 @@ describe('AddView', () => {
       drawImage: vi.fn(),
     });
     vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL').mockReturnValue(
-      'data:image/png;base64,testimg'
+      'data:image/jpeg;base64,testimg'
     );
 
     render(<AddView />);
@@ -263,7 +263,7 @@ describe('AddView', () => {
       drawImage: vi.fn(),
     });
     vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL').mockReturnValue(
-      'data:image/png;base64,testimg'
+      'data:image/jpeg;base64,testimg'
     );
 
     render(<AddView />);


### PR DESCRIPTION
## Summary
- save captured images as JPEG
- update tests to use JPEG data URLs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ba465fe4c832785f2af0cb7b11e2d