### PR TITLE
feat: view redis data

### DIFF
--- a/server/src/main/java/com/memoritta/server/controller/DataController.java
+++ b/server/src/main/java/com/memoritta/server/controller/DataController.java
@@ -18,6 +18,12 @@ public class DataController {
 
     private final BinaryDataManager binaryDataManager;
 
+    @GetMapping("/data/ids")
+    @Operation(summary = "List binary data IDs", description = "Returns all keys stored in Redis")
+    public java.util.List<String> listIds() {
+        return binaryDataManager.listKeys();
+    }
+
     @GetMapping("/data")
     @Operation(summary = "Load binary data", description = "Loads binary data by ID")
     public ResponseEntity<byte[]> loadData(

--- a/server/src/main/java/com/memoritta/server/manager/BinaryDataManager.java
+++ b/server/src/main/java/com/memoritta/server/manager/BinaryDataManager.java
@@ -21,4 +21,17 @@ public class BinaryDataManager {
     public byte[] load(UUID id) {
         return redisTemplate.opsForValue().get(id.toString());
     }
+
+    /**
+     * Get all keys stored in Redis.
+     *
+     * @return list of keys as strings
+     */
+    public java.util.List<String> listKeys() {
+        java.util.Set<String> keys = redisTemplate.keys("*");
+        if (keys == null) {
+            return java.util.List.of();
+        }
+        return new java.util.ArrayList<>(keys);
+    }
 }


### PR DESCRIPTION
## Summary
- list keys stored in Redis
- expose `/data/ids` to fetch Redis keys
- show Redis collection in the data view
- test selecting the Redis collection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bb7eb0d74832798282a9307f51547