### PR TITLE
Fix picture storage

### DIFF
--- a/server/src/main/java/com/memoritta/server/manager/ItemManager.java
+++ b/server/src/main/java/com/memoritta/server/manager/ItemManager.java
@@ -11,7 +11,6 @@ import com.memoritta.server.model.PictureOfItem;
 import java.util.Base64;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -27,7 +26,6 @@ public class ItemManager {
 
     private final UserRepository userRepository; // TODO: add support for JWT and remove this dependency (repository is not needed for JWT)
     private final ItemRepository itemRepository;
-    private final RedisTemplate<String, String> redisTemplate;
     private final BinaryDataManager binaryDataManager;
 
     public UUID saveItem(String name,
@@ -75,6 +73,7 @@ public class ItemManager {
                 PictureOfItem picture = pictures.get(0);
                 UUID pictureId = binaryDataManager.save(picture.getPicture());
                 picture.setId(pictureId);
+                picture.setPicture(null);
             }
         }
 

--- a/server/src/test/java/com/memoritta/server/manager/BinaryDataManagerTest.java
+++ b/server/src/test/java/com/memoritta/server/manager/BinaryDataManagerTest.java
@@ -1,0 +1,61 @@
+package com.memoritta.server.manager;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.test.context.ContextConfiguration;
+import redis.embedded.RedisServer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ContextConfiguration(classes = BinaryDataManagerTest.Config.class)
+class BinaryDataManagerTest {
+    private static RedisServer redisServer;
+
+    @BeforeAll
+    static void start() throws Exception {
+        redisServer = new RedisServer(7778);
+        redisServer.start();
+    }
+
+    @AfterAll
+    static void stop() {
+        if (redisServer != null) {
+            redisServer.stop();
+        }
+    }
+
+    @Configuration
+    static class Config {
+        @Bean
+        RedisConnectionFactory connectionFactory() {
+            return new LettuceConnectionFactory("localhost", 7778);
+        }
+
+        @Bean
+        BinaryDataManager binaryDataManager(RedisConnectionFactory factory) {
+            return new BinaryDataManager(new org.springframework.data.redis.core.RedisTemplate<>() {{
+                setConnectionFactory(factory);
+                afterPropertiesSet();
+            }});
+        }
+    }
+
+    @Autowired
+    private BinaryDataManager binaryDataManager;
+
+    @Test
+    void saveAndLoad_returnsSameBytes() {
+        byte[] data = new byte[] {1, 2, 3};
+        java.util.UUID id = binaryDataManager.save(data);
+        byte[] loaded = binaryDataManager.load(id);
+        assertThat(loaded).containsExactly(data);
+    }
+}

--- a/server/src/test/java/com/memoritta/server/manager/ItemManagerTest.java
+++ b/server/src/test/java/com/memoritta/server/manager/ItemManagerTest.java
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.util.List;
@@ -35,11 +34,6 @@ class ItemManagerTest {
         @Bean
         ItemRepository getItemRepository() {
             return mock(ItemRepository.class);
-        }
-
-        @Bean
-        RedisTemplate<String, String> getRedisTemplate() {
-            return mock(RedisTemplate.class);
         }
 
         @Bean


### PR DESCRIPTION
## Summary
- remove unused RedisTemplate from `ItemManager`
- store item images only in Redis
- add BinaryDataManager test for storing and loading bytes

## Testing
- `npm test --silent`
- `mvn -q -f server/pom.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68814893435c8327b0afdf4ddb2560af