### PR TITLE
Add debug logs for Redis handling

### DIFF
--- a/frontend/src/Data.jsx
+++ b/frontend/src/Data.jsx
@@ -45,6 +45,7 @@ export default function Data({ onBack = () => {} }) {
             }
             setDetails(map);
           } else if (collection === 'redis') {
+            console.debug('Loaded Redis IDs', data);
             setIds(data);
             setRedisData(null);
           } else {
@@ -80,7 +81,9 @@ export default function Data({ onBack = () => {} }) {
           if (collection === 'redis') {
             const array = await resp.arrayBuffer();
             const base64 = btoa(String.fromCharCode(...new Uint8Array(array)));
-            setRedisData(`data:image/jpeg;base64,${base64}`);
+            const img = `data:image/jpeg;base64,${base64}`;
+            console.debug('Loaded Redis data for', selectedId);
+            setRedisData(img);
           } else {
             const data = await resp.json();
             setDetails((prev) => ({ ...prev, [selectedId]: data }));
@@ -95,6 +98,12 @@ export default function Data({ onBack = () => {} }) {
       cancelled = true;
     };
   }, [selectedId, collection]);
+
+  useEffect(() => {
+    if (redisData) {
+      console.debug('Displaying Redis image');
+    }
+  }, [redisData]);
 
   if (selectedId) {
     if (collection === 'items') {

--- a/server/src/main/java/com/memoritta/server/controller/DataController.java
+++ b/server/src/main/java/com/memoritta/server/controller/DataController.java
@@ -4,6 +4,7 @@ import com.memoritta.server.manager.BinaryDataManager;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
 
+@Slf4j
 @RestController
 @AllArgsConstructor
 public class DataController {
@@ -21,6 +23,7 @@ public class DataController {
     @GetMapping("/data/ids")
     @Operation(summary = "List binary data IDs", description = "Returns all keys stored in Redis")
     public java.util.List<String> listIds() {
+        log.debug("Listing all Redis IDs");
         return binaryDataManager.listKeys();
     }
 
@@ -33,6 +36,7 @@ public class DataController {
         if (data == null) {
             return ResponseEntity.notFound().build();
         }
+        log.debug("Returning data with id {}", id);
         return ResponseEntity.ok()
                 .header("X-Data-Type", "picture")
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)

--- a/server/src/main/java/com/memoritta/server/manager/BinaryDataManager.java
+++ b/server/src/main/java/com/memoritta/server/manager/BinaryDataManager.java
@@ -1,11 +1,13 @@
 package com.memoritta.server.manager;
 
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.util.UUID;
 
+@Slf4j
 @Service
 @AllArgsConstructor
 public class BinaryDataManager {
@@ -14,11 +16,13 @@ public class BinaryDataManager {
 
     public UUID save(byte[] data) {
         UUID id = UUID.randomUUID();
+        log.debug("Saving data with id {} to Redis", id);
         redisTemplate.opsForValue().set(id.toString(), data);
         return id;
     }
 
     public byte[] load(UUID id) {
+        log.debug("Loading data with id {} from Redis", id);
         return redisTemplate.opsForValue().get(id.toString());
     }
 
@@ -28,6 +32,7 @@ public class BinaryDataManager {
      * @return list of keys as strings
      */
     public java.util.List<String> listKeys() {
+        log.debug("Listing all keys in Redis");
         java.util.Set<String> keys = redisTemplate.keys("*");
         if (keys == null) {
             return java.util.List.of();

--- a/server/src/main/java/com/memoritta/server/manager/ItemManager.java
+++ b/server/src/main/java/com/memoritta/server/manager/ItemManager.java
@@ -71,6 +71,7 @@ public class ItemManager {
             List<PictureOfItem> pictures = description.getPictures();
             if (pictures != null && !pictures.isEmpty()) {
                 PictureOfItem picture = pictures.get(0);
+                log.debug("Saving picture for item {} to Redis", item.getId());
                 UUID pictureId = binaryDataManager.save(picture.getPicture());
                 picture.setId(pictureId);
                 picture.setPicture(null);


### PR DESCRIPTION
## Summary
- add debug info for saved images in Redis
- log Redis key loading in REST API
- emit debug logs for image load and display in the UI

## Testing
- `mvn -q -pl server test` *(fails: Non-resolvable parent POM)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68814e39f410832792775a3fba908fc9