### PR TITLE
Display Redis data as text

### DIFF
--- a/frontend/src/Data.jsx
+++ b/frontend/src/Data.jsx
@@ -79,11 +79,9 @@ export default function Data({ onBack = () => {} }) {
         }
         if (resp && !cancelled && resp.ok) {
           if (collection === 'redis') {
-            const array = await resp.arrayBuffer();
-            const base64 = btoa(String.fromCharCode(...new Uint8Array(array)));
-            const img = `data:image/jpeg;base64,${base64}`;
+            const text = await resp.text();
             console.debug('Loaded Redis data for', selectedId);
-            setRedisData(img);
+            setRedisData(text);
           } else {
             const data = await resp.json();
             setDetails((prev) => ({ ...prev, [selectedId]: data }));
@@ -101,7 +99,7 @@ export default function Data({ onBack = () => {} }) {
 
   useEffect(() => {
     if (redisData) {
-      console.debug('Displaying Redis image');
+      console.debug('Displaying Redis text');
     }
   }, [redisData]);
 
@@ -133,8 +131,12 @@ export default function Data({ onBack = () => {} }) {
     }
     if (collection === 'redis') {
       return (
-        <div>
-          {redisData && <img src={redisData} alt="redis item" />}
+        <div className="redis-view">
+          <textarea
+            className="redis-textarea"
+            readOnly
+            value={redisData || ''}
+          />
           <footer className="view-footer">
             <button type="button" className="back-button" onClick={() => setSelectedId(null)}>
               Back

--- a/frontend/src/Data.test.jsx
+++ b/frontend/src/Data.test.jsx
@@ -130,4 +130,33 @@ describe('Data view', () => {
       })
     );
   });
+
+  it('loads redis data when id clicked', async () => {
+    const ids = ['d1'];
+    global.fetch = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, json: () => Promise.resolve(ids) })
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({ ok: true, text: () => Promise.resolve('text data') })
+      );
+    renderWithStore(<Data />);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'redis' } });
+    const btn = await screen.findByRole('button', { name: 'd1' });
+    fireEvent.click(btn);
+    const textarea = await screen.findByRole('textbox');
+    expect(textarea).toHaveValue('text data');
+    expect(global.fetch).toHaveBeenLastCalledWith(
+      `${BACKEND_URL}/data?id=d1`,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: `Basic ${btoa(`${AUTH_EMAIL}:${AUTH_PASSWORD}`)}`,
+        }),
+      })
+    );
+  });
 });

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -216,6 +216,16 @@ body.desktop .login-form {
   box-sizing: border-box;
 }
 
+.redis-view {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin: 0 auto;
+  padding: 1rem;
+  height: 100vh;
+  box-sizing: border-box;
+}
+
 .logs-textarea {
   width: 100%;
   box-sizing: border-box;
@@ -226,6 +236,14 @@ body.desktop .login-form {
   width: 100%;
   box-sizing: border-box;
   flex: 1;
+}
+
+.redis-textarea {
+  width: 100%;
+  box-sizing: border-box;
+  flex: 1;
+  white-space: pre-wrap;
+  overflow-y: auto;
 }
 
 body.desktop .ask-form {


### PR DESCRIPTION
## Summary
- display Redis data in a scrollable textarea instead of an image
- log when Redis text is shown
- style `redis-view` and `redis-textarea`
- test loading Redis data when clicking ID

## Testing
- `npm test`
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688317879698832798859427a89f2fa9