### PR TITLE
Fix OpenAI URL handling

### DIFF
--- a/server/src/main/java/com/memoritta/server/config/OpenAiConfig.java
+++ b/server/src/main/java/com/memoritta/server/config/OpenAiConfig.java
@@ -9,7 +9,9 @@ import org.springframework.context.annotation.Configuration;
 @Getter
 @Setter
 public class OpenAiConfig {
-    // Base URL for OpenAI services. Do not include the path to a specific endpoint.
+    // Base URL for OpenAI services.
+    // Should not contain a concrete endpoint like "/chat/completions".
+    // Defaults to "https://api.openai.com/v1".
     @Value("${openai.url:https://api.openai.com/v1}")
     private String url;
 
@@ -21,4 +23,29 @@ public class OpenAiConfig {
 
     @Value("${openai.project:}")
     private String project;
+
+    /**
+     * Returns a sanitized base URL for the OpenAI client.
+     * <p>
+     * Removes trailing "/chat/completions" if present and ensures the URL
+     * ends with "/v1".
+     */
+    public String getNormalizedUrl() {
+        String base = url == null ? "" : url.trim();
+
+        if (base.endsWith("/")) {
+            base = base.substring(0, base.length() - 1);
+        }
+
+        String suffix = "/chat/completions";
+        if (base.endsWith(suffix)) {
+            base = base.substring(0, base.length() - suffix.length());
+        }
+
+        if (!base.endsWith("/v1")) {
+            base = base + "/v1";
+        }
+
+        return base;
+    }
 }

--- a/server/src/main/java/com/memoritta/server/manager/OpenAiManager.java
+++ b/server/src/main/java/com/memoritta/server/manager/OpenAiManager.java
@@ -28,7 +28,7 @@ public class OpenAiManager {
         } else {
             this.client = OpenAIOkHttpClient.builder()
                     .apiKey(config.getApiKey())
-                    .baseUrl(config.getUrl())
+                    .baseUrl(config.getNormalizedUrl())
                     .organization(config.getOrganization())
                     .project(config.getProject())
                     .build();


### PR DESCRIPTION
## Summary
- sanitize OpenAI base URL to avoid accidentally sending requests to wrong endpoints
- update OpenAI manager to use the sanitized URL

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688463907da88327a61b5f2bb04348c2