### PR TITLE
Revert Redis format detection update

### DIFF
--- a/frontend/src/Data.jsx
+++ b/frontend/src/Data.jsx
@@ -5,28 +5,7 @@ import ItemDetails from './ItemDetails.jsx';
 import QuestionDetails from './QuestionDetails.jsx';
 import FriendDetails from './FriendDetails.jsx';
 
-function detectFormat(data) {
-  if (data instanceof Uint8Array) {
-    const startsWith = (arr) => arr.every((b, i) => data[i] === b);
-    if (startsWith([0xff, 0xd8, 0xff])) return 'JPEG';
-    if (startsWith([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))
-      return 'PNG';
-    if (
-      startsWith([0x47, 0x49, 0x46, 0x38, 0x37, 0x61]) ||
-      startsWith([0x47, 0x49, 0x46, 0x38, 0x39, 0x61])
-    )
-      return 'GIF';
-    if (
-      startsWith([0x52, 0x49, 0x46, 0x46]) &&
-      data[8] === 0x57 &&
-      data[9] === 0x45 &&
-      data[10] === 0x42 &&
-      data[11] === 0x50
-    )
-      return 'WEBP';
-    return 'Binary';
-  }
-  const text = data;
+function detectFormat(text) {
   if (text.startsWith('\xFF\xD8\xFF')) {
     return 'JPEG';
   }
@@ -139,23 +118,10 @@ export default function Data({ onBack = () => {} }) {
         }
         if (resp && !cancelled && resp.ok) {
           if (collection === 'redis') {
-            const type =
-              resp.headers && resp.headers.get
-                ? resp.headers.get('X-Data-Type')
-                : null;
-            if (type === 'picture') {
-              const array = await resp.arrayBuffer();
-              const bytes = new Uint8Array(array);
-              const base64 = btoa(String.fromCharCode(...bytes));
-              console.debug('Loaded Redis binary for', selectedId);
-              setRedisData(base64);
-              setRedisFormat(detectFormat(bytes));
-            } else {
-              const text = await resp.text();
-              console.debug('Loaded Redis data for', selectedId);
-              setRedisData(text);
-              setRedisFormat(detectFormat(text));
-            }
+            const text = await resp.text();
+            console.debug('Loaded Redis data for', selectedId);
+            setRedisData(text);
+            setRedisFormat(detectFormat(text));
           } else {
             const data = await resp.json();
             setDetails((prev) => ({ ...prev, [selectedId]: data }));
@@ -170,6 +136,13 @@ export default function Data({ onBack = () => {} }) {
       cancelled = true;
     };
   }, [selectedId, collection]);
+
+  useEffect(() => {
+    if (redisData) {
+      console.debug('Displaying Redis text');
+      setRedisFormat(detectFormat(redisData));
+    }
+  }, [redisData]);
 
   if (selectedId) {
     if (collection === 'items') {

--- a/frontend/src/Data.test.jsx
+++ b/frontend/src/Data.test.jsx
@@ -186,9 +186,7 @@ describe('Data view', () => {
 
   it('detects jpeg format from binary data', async () => {
     const ids = ['d1'];
-    const jpeg = new Uint8Array([
-      0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46,
-    ]);
+    const jpeg = '\xFF\xD8\xFF\xE0\x00\x10JFIF';
     global.fetch = vi
       .fn()
       .mockImplementationOnce(() =>
@@ -198,11 +196,7 @@ describe('Data view', () => {
         Promise.resolve({ ok: true, json: () => Promise.resolve(ids) })
       )
       .mockImplementationOnce(() =>
-        Promise.resolve({
-          ok: true,
-          headers: { get: () => 'picture' },
-          arrayBuffer: () => Promise.resolve(jpeg.buffer),
-        })
+        Promise.resolve({ ok: true, text: () => Promise.resolve(jpeg) })
       );
     renderWithStore(<Data />);
     fireEvent.change(screen.getByRole('combobox'), {


### PR DESCRIPTION
## Summary
- undo recent binary format detection changes

## Testing
- `npm test --silent`
- `mvn -q test` *(fails: Could not transfer artifact spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_6885d2b4fbc88327ba599be73423f356